### PR TITLE
Add release workflow for Github Actions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,51 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+
+jobs:
+  release:
+    permissions:
+      # Necessary permissions to create a release.
+      contents: write
+    env:
+      BUILD_DIR: build
+      BRANCH_NAME: ${{ github.event.repository.default_branch }}
+      RELEASE_BIN_ARCHIVE: qemu-ot-earlgrey-${{ inputs.release_tag }}-x86_64-unknown-linux-gnu.tar.gz
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      # Update the package index, then install all dependencies listed in
+      # the various apt-requirements.txt files in the project.
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build libpixman-1-dev
+      - name: Configure
+        run: |
+          mkdir "$BUILD_DIR"
+          cd "$BUILD_DIR"
+          ../configure --target-list=riscv32-softmmu --without-default-features --enable-tcg \
+            --enable-tools --enable-trace-backends=log
+      - name: Build
+        run: |
+          cd "$BUILD_DIR"
+          ninja
+          ninja qemu-img
+      - name: Create binary archive
+        run: |
+          ./scripts/opentitan/make_release.sh "$RELEASE_BIN_ARCHIVE" "$BUILD_DIR" .
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create \
+            --target "$BRANCH_NAME" \
+            ${{ inputs.release_tag }} \
+            --generate-notes \
+            "$RELEASE_BIN_ARCHIVE#QEMU system emulator"

--- a/scripts/opentitan/make_release.sh
+++ b/scripts/opentitan/make_release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Create a tarball containing the binaries and scripts necessary for opentitan.
+set -e
+
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 /path/to/output/tarball /path/to/build/dir /path/to/src/dir" >&2
+    exit 1
+fi
+
+OUT_TARBALL="$1"
+QEMU_BUILD_DIR="$2"
+QEMU_SRC_DIR="$3"
+# Create a temporary directory that we will tar.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+# Copy some binaries
+cp "$QEMU_BUILD_DIR/qemu-system-riscv32" "$TMP_DIR/"
+cp "$QEMU_BUILD_DIR/qemu-img" "$TMP_DIR/"
+cp "$QEMU_SRC_DIR/scripts/opentitan/otpconv.py" "$TMP_DIR/"
+cp "$QEMU_SRC_DIR/scripts/opentitan/flashgen.py" "$TMP_DIR/"
+# Create archive.
+tar --create --auto-compress --verbose --file="$OUT_TARBALL" --directory "$TMP_DIR/" .


### PR DESCRIPTION
This actions compiles the system emulator with the relevant options and creates an archive that contains this binary, as well as some OT relevant scripts to prepare OTP/flash images. The script uses the GitHub CLI to then create a release and publish the binary. This automatically tags the commit as well. GitHub takes care of creating an archive for the source code.

[Here is an example ](https://github.com/pamaury/qemu-ot/releases)of release created by this script.
