### PR TITLE
ot_kmac: fix cSHAKE/KMAC prefix handling

### DIFF
--- a/include/hw/opentitan/ot_entropy_src.h
+++ b/include/hw/opentitan/ot_entropy_src.h
@@ -34,10 +34,11 @@
 OBJECT_DECLARE_SIMPLE_TYPE(OtEntropySrcState, OT_ENTROPY_SRC)
 
 #define OT_ENTROPY_SRC_PACKET_SIZE_BITS 384u
-#define OT_ENTROPY_SRC_BYTE_COUNT       (OT_ENTROPY_SRC_PACKET_SIZE_BITS / 8u)
-#define OT_ENTROPY_SRC_WORD_COUNT       (OT_ENTROPY_SRC_BYTE_COUNT / sizeof(uint32_t))
+
+#define OT_ENTROPY_SRC_BYTE_COUNT (OT_ENTROPY_SRC_PACKET_SIZE_BITS / 8u)
+#define OT_ENTROPY_SRC_WORD_COUNT (OT_ENTROPY_SRC_BYTE_COUNT / sizeof(uint32_t))
 #define OT_ENTROPY_SRC_DWORD_COUNT \
-    ((OT_ENTROPY_SRC_BYTE_COUNT / sizeof(uint64_t)))
+    (OT_ENTROPY_SRC_BYTE_COUNT / sizeof(uint64_t))
 
 /* see hw/ip/edn/doc/#multiple-edns-in-boot-time-request-mode */
 #define OT_ENTROPY_SRC_BOOT_DELAY_NS 2000000u /* 2 ms */

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -465,7 +465,7 @@ sub top_of_kernel_tree {
 
 	my @tree_check = (
 		"COPYING", "MAINTAINERS", "Makefile",
-		"README.rst", "docs", "VERSION",
+		"README_QEMU.rst", "docs", "VERSION",
 		"linux-user", "softmmu"
 	);
 


### PR DESCRIPTION
Defer prefix processing to the point where cSHAKE init is done to avoid trying to parse prefixes in other modes. If prefix parsing fails, just emit a guest_error trace and continue processing (the resulting digest will obviously be wrong in this case).

KMAC prefix is still checked at START if KMAC_EN is set. This test is now similar to the RTL implementation, by matching the first 6 bytes of the prefix with a known value.

+ some minor non-related fixes