### PR TITLE
[ot] Fixed some typos in the opentitan documentation.

### DIFF
--- a/docs/opentitan/checkregs.md
+++ b/docs/opentitan/checkregs.md
@@ -3,7 +3,7 @@
 `checkregs.py` checks whether QEMU register definitions for OpenTitan match the generated OpenTitan
 `*_regs.h` files. This enables to spot major differences whenever OpenTitan definitions are updated.
 
-Note that only register addresses are checked for now, the bit assignement in each register is not
+Note that only register addresses are checked for now, the bit assignment in each register is not
 validated.
 
 ## Usage

--- a/docs/opentitan/earlgrey.md
+++ b/docs/opentitan/earlgrey.md
@@ -43,7 +43,7 @@ Devices in this group implement subset(s) of the real HW.
 * CSRNG
    * AES CTR not supported (uses xoroshiro128++ reseeded from entropy src)
 
-### Sparsely implemented adevices
+### Sparsely implemented devices
 
 In this group, device CSRs are supported (w/ partial or full access control & masking) but only some
 features are implemented.
@@ -96,7 +96,7 @@ generate the `.raw` image files.
 
 ## Available tools
 
-Launching a QEMU VM with the right option switches may rapidely become complex due to the number
+Launching a QEMU VM with the right option switches may rapidly become complex due to the number
 of options and the available features. Several helper tools are provided in the `scripts/opentitan`
 directory to help with these tasks.
 
@@ -118,7 +118,7 @@ directory to help with these tasks.
 ### vCPU
 
 * `-icount 6` reduces the execution speed of the vCPU (Ibex core) to 1GHz >> 6, _i.e._ ~15MHz,
-  which should roughly match the expected speed of the Ibex core runninng on the CW310 FPGA, which
+  which should roughly match the expected speed of the Ibex core running on the CW310 FPGA, which
   is set to 10 MHz. This option is very useful/mandatory to run many OpenTitan tests that rely on
   time or CPU cycle to validate features. Using `-icount` option slows down execution speed though,
   so it is not recommended to use it when the main goal is to develop SW to run on the virtual
@@ -133,7 +133,7 @@ directory to help with these tasks.
 
 ### AES
 
-* `-global ot-aes.fast-mode=false` can be used to better emulate AES HW IP, as some OT tests expects
+* `-global ot-aes.fast-mode=false` can be used to better emulate AES HW IP, as some OT tests expect
   the Ibex core to execute while the HW is performing AES rounds. Without this option, the virtual
   HW may only give back execution to the vCPU once the AES operation is complete, which make those
   OT tests to fail. Disabling fast mode better emulates the HW to the expense of higher AES latency
@@ -216,7 +216,7 @@ to enumerate these log features, however the most useful ones are enumerated her
 
    * `unimp` reports log messages for unimplemented features, _e.g._ when the vCPU attempts to
      read from or write into a memory mapped device that has not been implemented.
-   * `guest_errors` repots log messages of invalid guest software requests, _e.g._ attempts to
+   * `guest_errors` reports log messages of invalid guest software requests, _e.g._ attempts to
      perform an invalid configuration.
    * `int` reports all interruptions *and* exceptions handled by the vCPU. It may be quite verbose
      but also very useful to track down an invalid memory or I/O access for example. This is the

--- a/docs/opentitan/flashgen.md
+++ b/docs/opentitan/flashgen.md
@@ -42,10 +42,10 @@ The (signed) binary files contain no symbols, which can make low-level debugging
 when using the `-d in_asm` and/or `-d exec` option switches.
 
 If an ELF file with the same radix as a binary file is located in the directory of the binary
-file, or its location is specified with on the command line, the path to the ELF file is encoded
-into the flash image into a dedicated debug section.
+file, or its location is specified in the command line, the path to the ELF file is encoded
+into the flash image within a dedicated debug section.
 
-The OT flash controller emulation, when the stored ELF file exists, attemps to load the symbols
+The OT flash controller emulation, when the stored ELF file exists, attempts to load the symbols
 from this ELF file into QEMU disassembler. This enables the QEMU disassembler - used with the
 `in_asm`/`exec` QEMU options - to output the name of each executed function as an addition to the
 guest PC value.
@@ -58,7 +58,7 @@ matching signed binary files to help with debugging.
 * `-a bank` specify the data partition to store the binary file into, mutually exclusive with `-t`.
 
 * `-B elf` specify an alternative path to the BL0 ELF file. If not specified, the ELF path file is
-  recontructed from the specified binary file (from the same directory). The ELF file is only used
+  reconstructed from the specified binary file (from the same directory). The ELF file is only used
   as a hint for QEMU loader. Requires option `-b`, mutually exclusive with `-t`.
 
 * `-b file` specify the BL0 (signed) binary file to store in the data partition of the flash
@@ -82,7 +82,7 @@ matching signed binary files to help with debugging.
   This option is mutually exclusive with `-b`, `-B`, `-x`, `-X` and `-a`.
 
 * `-X elf` specify an alternative path to the ROM_EXT ELF file. If not specified, the ELF path file
-  is recontructed from the specified binary file (from the same directory). The ELF file is only
+  is reconstructed from the specified binary file (from the same directory). The ELF file is only
   used as a hint for QEMU loader. Requires option `-x`, mutually exclusive with `-t`.
 
 * `-x file` specify the ROM_EXT (signed) binary file or the application to store into the data

--- a/docs/opentitan/otpconv.md
+++ b/docs/opentitan/otpconv.md
@@ -43,7 +43,7 @@ This script works in three different modes.
 
 * `-b` byte-swap in input VMEM words (should work Ok w/o this option)
 
-* `-c` specify the register file, which is only useful to decoce OTP content (see `-s` option)
+* `-c` specify the register file, which is only useful to decode OTP content (see `-s` option)
 
 * `-d` only useful to debug the script, reports any Python traceback to the standard error stream.
 

--- a/docs/opentitan/pyot.md
+++ b/docs/opentitan/pyot.md
@@ -52,7 +52,7 @@ Files:
 
 This tool may be used in two ways, which can be combined:
 
-* From the command line, it is possible to run a QEMU test session for one application,
+* From the command line, it is possible to run a QEMU test session for one application.
 * Using a JSON configuration file, it is possible to run several QEMU test sessions for each
   specified test in the configuration file. This mode is enabled when a JSON config file is
   specified.
@@ -427,7 +427,7 @@ Sample config for running some non-OpenTitan tests:
   This section defines shortcut to further reduce the definition and report of test filenames.
 
   Any test filename ending up with one of the suffixes is automatically stripped. Further test
-  configuration in the the `tests` section should omit this suffix. The generated test report also
+  configuration in the `tests` section should omit this suffix. The generated test report also
   omit these suffixes.
 
 * `tests`
@@ -456,7 +456,7 @@ commands:
     session is over
 
 Regular or 'synchronous' commands are only executed if all the previous commands have been
-succesful. Moreover, commands in the `post` subsection are only executed if the QEMU session has
+successful. Moreover, commands in the `post` subsection are only executed if the QEMU session has
 completed successfully.
 
 Background commands are commands that run in the background till they complete on their own, or
@@ -497,7 +497,7 @@ aes_test,pass,0.044,6,
 
 ## Return value
 
-The script returns the error code of the most occuring error, or success (0)
+The script returns the error code of the most occurring error, or success (0)
 
 ## Examples
 


### PR DESCRIPTION
The documentation is brilliant, thank you!

Here are a few small typos I found, while reading up on this qemu fork.