### PR TITLE
[ci] Build releases on Ubuntu 20.04

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -15,7 +15,7 @@ jobs:
       BUILD_DIR: build
       BRANCH_NAME: ${{ github.event.repository.default_branch }}
       RELEASE_BIN_ARCHIVE: qemu-ot-earlgrey-${{ inputs.release_tag }}-x86_64-unknown-linux-gnu.tar.gz
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
       - name: Check out repository


### PR DESCRIPTION
We're currently building our releases in an "ubuntu-latest" container, which uses Ubuntu 22.04.

The binaries built here use features of glibc 2.32 and up (see https://github.com/lowRISC/opentitan/pull/19420#pullrequestreview-1589948328).

OpenTitan is set up to officially support Ubuntu 20.04. This is the OS that CI and the dev container run with. This version of Ubuntu only has glibc 2.31, and so we cannot use these binaries there.

This PR changes the version of Ubuntu used to build the binaries to Ubuntu 20.04 for compatibility. These should still be usable in Ubuntu 22.04 and up.