### PR TITLE
[ot] Restructure the release tarball and update the ci

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -39,7 +39,7 @@ jobs:
           ninja qemu-img
       - name: Create binary archive
         run: |
-          ./scripts/opentitan/make_release.sh "$RELEASE_BIN_ARCHIVE" "$BUILD_DIR" .
+          ./scripts/opentitan/make_release.sh "$RELEASE_BIN_ARCHIVE" . "$BUILD_DIR"
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/opentitan/make_release.sh
+++ b/scripts/opentitan/make_release.sh
@@ -7,20 +7,15 @@
 set -e
 
 if [ $# -ne 3 ]; then
-    echo "Usage: $0 /path/to/output/tarball /path/to/build/dir /path/to/src/dir" >&2
+    echo "Usage: $0 /path/to/output/tarball /path/to/src/dir build_dirname" >&2
     exit 1
 fi
 
 OUT_TARBALL="$1"
-QEMU_BUILD_DIR="$2"
-QEMU_SRC_DIR="$3"
-# Create a temporary directory that we will tar.
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
-# Copy some binaries
-cp "$QEMU_BUILD_DIR/qemu-system-riscv32" "$TMP_DIR/"
-cp "$QEMU_BUILD_DIR/qemu-img" "$TMP_DIR/"
-cp "$QEMU_SRC_DIR/scripts/opentitan/otpconv.py" "$TMP_DIR/"
-cp "$QEMU_SRC_DIR/scripts/opentitan/flashgen.py" "$TMP_DIR/"
+QEMU_DIR="$2"
+QEMU_BUILD="$3"
 # Create archive.
-tar --create --auto-compress --verbose --file="$OUT_TARBALL" --directory "$TMP_DIR/" .
+tar --create --auto-compress --verbose --file="$OUT_TARBALL" \
+    --directory="$QEMU_DIR" \
+    "$QEMU_BUILD"/qemu-{system-riscv32,img} \
+    scripts/opentitan/{otpconv,flashgen}.py


### PR DESCRIPTION
This commit restructure the archive to look like this:
```
.
├── build
│   ├── qemu-img
│   └── qemu-system-riscv32
└── scripts
    └── opentitan
        ├── flashgen.py
        └── otpconv.py
```
It also permutes the src and build arguments for the release script because it makes more sense.

**Context:** the idea is to make it easier to develop on qemu while using bazel. The bazel is still [WIP](https://github.com/lowRISC/opentitan/pull/19420) but the intention is that one will be able to use it either with an official release, or a a local checkout since they have the same directory structure.