### PR TITLE
[ot] hw/opentitan: fix invalid printf-style format of log messages

### DIFF
--- a/hw/opentitan/ot_aes.c
+++ b/hw/opentitan/ot_aes.c
@@ -1003,7 +1003,7 @@ static uint64_t ot_aes_read(void *opaque, hwaddr addr, unsigned size)
     case R_DATA_IN_3:
     case R_TRIGGER:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0u;
         break;
@@ -1085,7 +1085,7 @@ static void ot_aes_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_DATA_OUT_3:
     case R_STATUS:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     case R_KEY_SHARE0_0:

--- a/hw/opentitan/ot_alert.c
+++ b/hw/opentitan/ot_alert.c
@@ -285,7 +285,7 @@ static uint64_t ot_alert_regs_read(void *opaque, hwaddr addr, unsigned size)
         val32 = regs->ping.timer_en_shadowed;
         break;
     case R_INTR_TEST:
-        qemu_log_mask(LOG_GUEST_ERROR, "W/O register 0x02%" HWADDR_PRIx "\n",
+        qemu_log_mask(LOG_GUEST_ERROR, "W/O register 0x%03" HWADDR_PRIx "\n",
                       addr);
         val32 = 0;
         break;
@@ -594,7 +594,7 @@ static void ot_alert_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case CASE_STRIDE(R_CLASS_STATE, ALERT_CLASSB):
     case CASE_STRIDE(R_CLASS_STATE, ALERT_CLASSC):
     case CASE_STRIDE(R_CLASS_STATE, ALERT_CLASSD):
-        qemu_log_mask(LOG_GUEST_ERROR, "R/O register 0x02%" HWADDR_PRIx "\n",
+        qemu_log_mask(LOG_GUEST_ERROR, "R/O register 0x%03" HWADDR_PRIx "\n",
                       addr);
         break;
     default:

--- a/hw/opentitan/ot_aon_timer.c
+++ b/hw/opentitan/ot_aon_timer.c
@@ -319,7 +319,7 @@ static uint64_t ot_aon_timer_read(void *opaque, hwaddr addr, unsigned size)
     case R_ALERT_TEST:
     case R_INTR_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;

--- a/hw/opentitan/ot_clkmgr.c
+++ b/hw/opentitan/ot_clkmgr.c
@@ -293,7 +293,7 @@ static uint64_t ot_clkmgr_read(void *opaque, hwaddr addr, unsigned size)
         break;
     case R_ALERT_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -524,7 +524,7 @@ static void ot_clkmgr_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_CLK_HINTS_STATUS:
     case R_FATAL_ERR_CODE:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "%s: R/O register 0x02%" HWADDR_PRIx " (%s)\n", __func__,
+                      "%s: R/O register 0x%02" HWADDR_PRIx " (%s)\n", __func__,
                       addr, REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_csrng.c
+++ b/hw/opentitan/ot_csrng.c
@@ -1575,7 +1575,7 @@ static uint64_t ot_csrng_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_ALERT_TEST:
     case R_CMD_REQ:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -1713,7 +1713,7 @@ static void ot_csrng_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_ERR_CODE:
     case R_MAIN_SM_STATE:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_edn.c
+++ b/hw/opentitan/ot_edn.c
@@ -1077,7 +1077,7 @@ static uint64_t ot_edn_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_RESEED_CMD:
     case R_GENERATE_CMD:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -1240,7 +1240,7 @@ static void ot_edn_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_ERR_CODE:
     case R_MAIN_SM_STATE:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_entropy_src.c
+++ b/hw/opentitan/ot_entropy_src.c
@@ -1212,7 +1212,7 @@ ot_entropy_src_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_ALERT_TEST:
     case R_FW_OV_WR_DATA:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "%s: W/O register 0x02%" HWADDR_PRIx " (%s)\n", __func__,
+                      "%s: W/O register 0x%02" HWADDR_PRIx " (%s)\n", __func__,
                       addr, REG_NAME(reg));
         val32 = 0;
         break;
@@ -1500,7 +1500,7 @@ static void ot_entropy_src_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_ERR_CODE:
     case R_MAIN_SM_STATE:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "%s: R/O register 0x02%" HWADDR_PRIx " (%s)\n", __func__,
+                      "%s: R/O register 0x%02" HWADDR_PRIx " (%s)\n", __func__,
                       addr, REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -985,7 +985,7 @@ static uint64_t ot_flash_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_ALERT_TEST:
     case R_PROG_FIFO:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%03" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -1268,7 +1268,7 @@ static void ot_flash_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_PHY_STATUS:
     case R_CURR_FIFO_LVL:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%03" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -350,7 +350,7 @@ static uint64_t ot_hmac_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_KEY_6:
     case R_KEY_7:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -501,7 +501,7 @@ static void ot_hmac_regs_write(void *opaque, hwaddr addr, uint64_t value,
     case R_MSG_LENGTH_LOWER:
     case R_MSG_LENGTH_UPPER:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_kmac.c
+++ b/hw/opentitan/ot_kmac.c
@@ -1131,7 +1131,7 @@ static uint64_t ot_kmac_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_KEY_SHARE1_15:
     case R_KEY_LEN:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "%s: W/O register 0x02%" HWADDR_PRIx " (%s)\n", __func__,
+                      "%s: W/O register 0x%02" HWADDR_PRIx " (%s)\n", __func__,
                       addr, REG_NAME(reg));
         val32 = 0;
         break;
@@ -1311,7 +1311,7 @@ static void ot_kmac_regs_write(void *opaque, hwaddr addr, uint64_t value,
     case R_ENTROPY_REFRESH_HASH_CNT:
     case R_ERR_CODE:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "%s: R/O register 0x02%" HWADDR_PRIx " (%s)\n", __func__,
+                      "%s: R/O register 0x%02" HWADDR_PRIx " (%s)\n", __func__,
                       addr, REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_lifecycle.c
+++ b/hw/opentitan/ot_lifecycle.c
@@ -387,7 +387,7 @@ static uint64_t ot_lifecycle_regs_read(void *opaque, hwaddr addr, unsigned size)
         break;
     case R_ALERT_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -501,7 +501,7 @@ static void ot_lifecycle_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_MANUF_STATE_6:
     case R_MANUF_STATE_7:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_otp_earlgrey.c
+++ b/hw/opentitan/ot_otp_earlgrey.c
@@ -865,7 +865,7 @@ static uint64_t ot_otp_eg_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_INTR_TEST:
     case R_ALERT_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%03" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -963,7 +963,7 @@ static void ot_otp_eg_regs_write(void *opaque, hwaddr addr, uint64_t value,
     case R_SECRET2_DIGEST_0:
     case R_SECRET2_DIGEST_1:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%03" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:
@@ -1103,7 +1103,7 @@ static void ot_otp_eg_swcfg_write(void *opaque, hwaddr addr, uint64_t value,
 
     hwaddr reg = R32_OFF(addr);
 
-    qemu_log_mask(LOG_GUEST_ERROR, "R/O register 0x02%" HWADDR_PRIx " (%s)\n",
+    qemu_log_mask(LOG_GUEST_ERROR, "R/O register 0x%03" HWADDR_PRIx " (%s)\n",
                   addr, ot_otp_eg_swcfg_reg_name(reg));
 }
 
@@ -1159,7 +1159,7 @@ static void ot_otp_eg_csrs_write(void *opaque, hwaddr addr, uint64_t value,
         break;
     case R_CSR7:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%01" HWADDR_PRIx " (%s)\n", addr,
                       CSR_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_pinmux.c
+++ b/hw/opentitan/ot_pinmux.c
@@ -269,7 +269,7 @@ static uint64_t ot_pinmux_regs_read(void *opaque, hwaddr addr, unsigned size)
         val32 = regs->wkup_cause;
         break;
     case CASE_SCALAR(ALERT_TEST):
-        qemu_log_mask(LOG_GUEST_ERROR, "W/O register 0x02%" HWADDR_PRIx "\n",
+        qemu_log_mask(LOG_GUEST_ERROR, "W/O register 0x%03" HWADDR_PRIx "\n",
                       addr);
         val32 = 0;
         break;

--- a/hw/opentitan/ot_pwrmgr.c
+++ b/hw/opentitan/ot_pwrmgr.c
@@ -263,7 +263,7 @@ static uint64_t ot_pwrmgr_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_INTR_TEST:
     case R_ALERT_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -358,7 +358,7 @@ static void ot_pwrmgr_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_ESCALATE_RESET_STATUS:
     case R_FAULT_STATUS:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_rom_ctrl.c
+++ b/hw/opentitan/ot_rom_ctrl.c
@@ -228,7 +228,7 @@ static uint64_t ot_rom_ctrl_regs_read(void *opaque, hwaddr addr, unsigned size)
         break;
     case R_ALERT_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -282,7 +282,7 @@ static void ot_rom_ctrl_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_EXP_DIGEST_6:
     case R_EXP_DIGEST_7:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "%s: R/O register 0x02%" HWADDR_PRIx " (%s)\n", __func__,
+                      "%s: R/O register 0x%02" HWADDR_PRIx " (%s)\n", __func__,
                       addr, REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_sensor.c
+++ b/hw/opentitan/ot_sensor.c
@@ -178,7 +178,7 @@ static uint64_t ot_sensor_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_INTR_TEST:
     case R_ALERT_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -235,12 +235,12 @@ static void ot_sensor_regs_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_RECOV_ALERT:
     case R_FATAL_ALERT:
         qemu_log_mask(LOG_UNIMP,
-                      "Unimplemented register 0x02%" HWADDR_PRIx " (%s)\n",
+                      "Unimplemented register 0x%02" HWADDR_PRIx " (%s)\n",
                       addr, REG_NAME(reg));
         break;
     case R_STATUS:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_spi_host.c
+++ b/hw/opentitan/ot_spi_host.c
@@ -934,7 +934,7 @@ static uint64_t ot_spi_host_read(void *opaque, hwaddr addr, unsigned int size)
     case R_COMMAND:
     case R_TXDATA:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0u;
         break;
@@ -1144,7 +1144,7 @@ static void ot_spi_host_write(void *opaque, hwaddr addr, uint64_t val64,
     }
     case R_RXDATA:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         break;
     case R_TXDATA: {

--- a/hw/opentitan/ot_sram_ctrl.c
+++ b/hw/opentitan/ot_sram_ctrl.c
@@ -121,7 +121,7 @@ static uint64_t ot_sram_ctrl_regs_read(void *opaque, hwaddr addr, unsigned size)
         break;
     case R_ALERT_TEST:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -188,7 +188,7 @@ static void ot_sram_ctrl_regs_write(void *opaque, hwaddr addr, uint64_t val64,
         break;
     case R_STATUS:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "%s: R/O register 0x02%" HWADDR_PRIx " (%s)\n", __func__,
+                      "%s: R/O register 0x%02" HWADDR_PRIx " (%s)\n", __func__,
                       addr, REG_NAME(reg));
         break;
     default:

--- a/hw/opentitan/ot_timer.c
+++ b/hw/opentitan/ot_timer.c
@@ -224,7 +224,7 @@ static uint64_t ot_timer_read(void *opaque, hwaddr addr, unsigned size)
     case R_ALERT_TEST:
     case R_INTR_TEST0:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;

--- a/hw/opentitan/ot_uart.c
+++ b/hw/opentitan/ot_uart.c
@@ -429,7 +429,7 @@ static uint64_t ot_uart_read(void *opaque, hwaddr addr, unsigned int size)
     case R_INTR_TEST:
     case R_WDATA:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "W/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "W/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;
@@ -522,7 +522,7 @@ static void ot_uart_write(void *opaque, hwaddr addr, uint64_t val64,
     case R_FIFO_STATUS:
     case R_VAL:
         qemu_log_mask(LOG_GUEST_ERROR,
-                      "R/O register 0x02%" HWADDR_PRIx " (%s)\n", addr,
+                      "R/O register 0x%02" HWADDR_PRIx " (%s)\n", addr,
                       REG_NAME(reg));
         val32 = 0;
         break;


### PR DESCRIPTION
The original log messages have been imported from upstream and copy/pasted with the error that propagates through all OT files.

Some OT devices use register addresses > 0xff, so update the log format to 0x03x in this case.