### PR TITLE
[ot] hw/opentitan: fix jtag component build

### DIFF
--- a/jtag/meson.build
+++ b/jtag/meson.build
@@ -1,1 +1,1 @@
-common_ss.add(files('jtag_bitbang.c'))
+system_ss.add(files('jtag_bitbang.c'))


### PR DESCRIPTION
JTAG requires CharDevice which is not available on user-only emulation. Build JTAG component only for system builds