### PR TITLE
Revert usage of Resettable API for Hart reset

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -689,11 +689,11 @@ static inline bool cpu_handle_halt(CPUState *cpu)
             return true;
         }
 
-        cpu->halted = cpu->on_reset;
+        cpu->halted = 0;
     }
 #endif /* !CONFIG_USER_ONLY */
 
-    return cpu->on_reset;
+    return false;
 }
 
 static inline void cpu_handle_debug_exception(CPUState *cpu)

--- a/hw/core/cpu-common.c
+++ b/hw/core/cpu-common.c
@@ -116,34 +116,15 @@ void cpu_reset(CPUState *cpu)
     trace_cpu_reset(cpu->cpu_index);
 }
 
-static void cpu_common_reset_enter(Object *obj, ResetType type)
-{
-    CPUState *cpu = CPU(obj);
-    CPUClass *cc = CPU_GET_CLASS(cpu);
-    cpu->on_reset = true;
-
-    if (qemu_loglevel_mask(CPU_LOG_RESET)) {
-        qemu_log("CPU Reset Enter (CPU %d)\n", cpu->cpu_index);
-        log_cpu_state(cpu, cc->reset_dump_flags);
-    }
-}
-
-static void cpu_common_reset_exit(Object *obj)
-{
-    CPUState *cpu = CPU(obj);
-    cpu->on_reset = false;
-    cpu->halted = 0;
-    if (qemu_loglevel_mask(CPU_LOG_RESET)) {
-        CPUClass *cc = CPU_GET_CLASS(cpu);
-        qemu_log("CPU Reset Exit (CPU %d) PC:0x%" VADDR_PRIx "\n",
-                 cpu->cpu_index, cc->get_pc(cpu));
-    }
-    cpu_resume(cpu);
-}
-
 static void cpu_common_reset_hold(Object *obj)
 {
     CPUState *cpu = CPU(obj);
+    CPUClass *cc = CPU_GET_CLASS(cpu);
+
+    if (qemu_loglevel_mask(CPU_LOG_RESET)) {
+        qemu_log("CPU Reset (CPU %d)\n", cpu->cpu_index);
+        log_cpu_state(cpu, cc->reset_dump_flags);
+    }
 
     cpu->interrupt_request = 0;
     cpu->halted = cpu->start_powered_off;
@@ -289,9 +270,7 @@ static void cpu_class_init(ObjectClass *klass, void *data)
     set_bit(DEVICE_CATEGORY_CPU, dc->categories);
     dc->realize = cpu_common_realizefn;
     dc->unrealize = cpu_common_unrealizefn;
-    rc->phases.enter = cpu_common_reset_enter;
     rc->phases.hold = cpu_common_reset_hold;
-    rc->phases.exit = cpu_common_reset_exit;
     cpu_class_init_props(dc);
     /*
      * Reason: CPUs still need special care by board code: wiring up

--- a/hw/opentitan/ot_pwrmgr.c
+++ b/hw/opentitan/ot_pwrmgr.c
@@ -247,9 +247,10 @@ static void ot_pwrmgr_rom_done(void *opaque, int irq, int level)
     /* if all ROM checks are done, start vCPU or report error */
     if (done) {
         if (good) {
-            CPUState *cs = ot_common_get_local_cpu(DEVICE(s));
-            if (cs) {
-                resettable_release_reset(OBJECT(cs), RESET_TYPE_COLD);
+            CPUState *cpu = ot_common_get_local_cpu(DEVICE(s));
+            if (cpu) {
+                cpu->halted = 0;
+                cpu_resume(cpu);
             } else {
                 error_report("ot_pwrmgr: Could not find a vCPU to start!");
             }

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1011,12 +1011,7 @@ static void ot_darjeeling_soc_reset_hold(Object *obj)
     resettable_assert_reset(OBJECT(s->devices[OT_DARJEELING_SOC_DEV_ROM1]),
                             RESET_TYPE_COLD);
 
-    /*
-     * leave hart on reset
-     * power manager should release it once ROMs have been validated
-     */
-    CPUState *cs = CPU(s->devices[OT_DARJEELING_SOC_DEV_HART]);
-    resettable_assert_reset(OBJECT(cs), RESET_TYPE_COLD);
+    cpu_reset(CPU(s->devices[OT_DARJEELING_SOC_DEV_HART]));
 }
 
 static void ot_darjeeling_soc_reset_exit(Object *obj)

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -977,12 +977,7 @@ static void ot_earlgrey_soc_reset_hold(Object *obj)
     resettable_assert_reset(OBJECT(s->devices[OT_EARLGREY_SOC_DEV_ROM_CTRL]),
                             RESET_TYPE_COLD);
 
-    /*
-     * leave hart on reset
-     * power manager should release it once ROM has been validated
-     */
-    CPUState *cs = CPU(s->devices[OT_EARLGREY_SOC_DEV_HART]);
-    resettable_assert_reset(OBJECT(cs), RESET_TYPE_COLD);
+    cpu_reset(CPU(s->devices[OT_EARLGREY_SOC_DEV_HART]));
 }
 
 static void ot_earlgrey_soc_reset_exit(Object *obj)

--- a/include/hw/core/cpu.h
+++ b/include/hw/core/cpu.h
@@ -348,7 +348,6 @@ struct CPUState {
 
     /* Should CPU start in powered-off state? */
     bool start_powered_off;
-    bool on_reset;
 
     bool unplug;
     bool crash_occurred;

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -900,6 +900,8 @@ static void riscv_cpu_reset_hold(Object *obj)
     }
     env->mcause = 0;
     env->miclaim = MIP_SGEIP;
+    env->pc = env->resetvec;
+    env->mtvec = cpu->cfg.mtvec;
     env->bins = 0;
     env->two_stage_lookup = false;
 
@@ -959,24 +961,6 @@ static void riscv_cpu_reset_hold(Object *obj)
 
     env->mseccfg = (target_ulong)cfg->mseccfg;
 #endif
-}
-
-static void riscv_cpu_reset_exit(Object *obj)
-{
-    CPUState *cs = CPU(obj);
-    RISCVCPU *cpu = RISCV_CPU(cs);
-    RISCVCPUClass *mcc = RISCV_CPU_GET_CLASS(cpu);
-    CPURISCVState *env = &cpu->env;
-
-#ifndef CONFIG_USER_ONLY
-    /* reset vector and mtvec may be updated while hart is in reset */
-    env->pc = env->resetvec;
-    env->mtvec = cpu->cfg.mtvec;
-#endif
-
-    if (mcc->parent_phases.exit) {
-        mcc->parent_phases.exit(obj);
-    }
 }
 
 static void riscv_cpu_disas_set_info(CPUState *s, disassemble_info *info)
@@ -2215,8 +2199,7 @@ static void riscv_cpu_class_init(ObjectClass *c, void *data)
     device_class_set_parent_realize(dc, riscv_cpu_realize,
                                     &mcc->parent_realize);
 
-    resettable_class_set_parent_phases(rc, NULL, riscv_cpu_reset_hold,
-                                       riscv_cpu_reset_exit,
+    resettable_class_set_parent_phases(rc, NULL, riscv_cpu_reset_hold, NULL,
                                        &mcc->parent_phases);
 
     cc->class_by_name = riscv_cpu_class_by_name;


### PR DESCRIPTION
Additional internal review at Rivos found some issues for non-Ibex CPU use case.

We'll submit a revised version later.