### PR TITLE
[ot] hw/opentitan: fix SPI device busy bit calculation

### DIFF
--- a/hw/opentitan/ot_spi_device.c
+++ b/hw/opentitan/ot_spi_device.c
@@ -1162,7 +1162,7 @@ static void ot_spi_device_flash_decode_command(OtSPIDeviceState *s, uint8_t cmd)
             return;
         }
 
-        bool set_busy = (bool)f->cmd_info & CMD_INFO_BUSY_MASK;
+        bool set_busy = (bool) (f->cmd_info & CMD_INFO_BUSY_MASK);
         if (set_busy) {
             s->spi_regs[R_FLASH_STATUS] |= R_FLASH_STATUS_BUSY_MASK;
         }


### PR DESCRIPTION
This PR fixes an operator precedence bug in the virtual SPI device. I noticed that the SPI device's busy bit wasn't being set after receiving commands, regardless of how the command info register was configured. This change corrects the issue.