### PR TITLE
Darjeeling updates

### DIFF
--- a/.gitlab-ci.d/opentitan/build.yml
+++ b/.gitlab-ci.d/opentitan/build.yml
@@ -63,7 +63,8 @@ format:
   script:
     - scripts/opentitan/ot-format.sh --ci -i
     - git status -s
-    - test $(git status -s | wc -l) -eq 0
+    - test -z "$(git status -s)" || git diff
+    - test -z "$(git status -s)"
 
 tidy:
   tags:

--- a/.gitlab-ci.d/opentitan/qemu-ot.yml
+++ b/.gitlab-ci.d/opentitan/qemu-ot.yml
@@ -1,5 +1,5 @@
 variables:
-  BAREMETAL_REF: "240604-2"
+  BAREMETAL_REF: "240606-1"
   QEMU_BUILD_OPTS: ""
 
 include:

--- a/docs/opentitan/rom_ctrl.md
+++ b/docs/opentitan/rom_ctrl.md
@@ -47,7 +47,8 @@ The ROM image ID may depend on the SoC.
 
 * for EarlGrey which has a single ROM, the ID is expected to be `rom`.
 * for a SoC with two ROMs, the IDs would be expected to be `rom0` and `rom1`.
-* for a machine with multiple SoCs, the IDs would be additionnally prefixed with the SoC name.
+* for a machine with multiple SoCs, the IDs would be additionnally prefixed with the SoC name and a
+  full stop, _e.g._ `soc0.rom0`
 
 ## Booting with and without ROM
 

--- a/hw/misc/pulp_rv_dm.c
+++ b/hw/misc/pulp_rv_dm.c
@@ -497,24 +497,24 @@ static void pulp_rv_dm_init(Object *obj)
 
     /* Top-level MMIO */
     memory_region_init_io(&s->regs, obj, &pulp_rv_dm_regs_ops, s,
-                          TYPE_PULP_RV_DM "-regs", PULP_RV_DM_REGS_SIZE);
+                          TYPE_PULP_RV_DM ".regs", PULP_RV_DM_REGS_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->regs);
 
     /* Mem container content */
     memory_region_init_io(&s->dmact, obj, &pulp_rv_dm_dmact_ops, s,
-                          TYPE_PULP_RV_DM "-act", PULP_RV_DM_DMACT_SIZE);
+                          TYPE_PULP_RV_DM ".act", PULP_RV_DM_DMACT_SIZE);
     memory_region_add_subregion(&s->mem, PULP_RV_DM_DMACT_BASE, &s->dmact);
 
-    memory_region_init_ram_nomigrate(&s->prog, obj, TYPE_PULP_RV_DM "-prog",
+    memory_region_init_ram_nomigrate(&s->prog, obj, TYPE_PULP_RV_DM ".prog",
                                      PULP_RV_DM_PROG_SIZE, &error_fatal);
     memory_region_add_subregion(&s->mem, PULP_RV_DM_PROG_BASE, &s->prog);
 
     memory_region_init_io(&s->dmflag, obj, &pulp_rv_dm_dmflag_ops, s,
-                          TYPE_PULP_RV_DM "-flag", PULP_RV_DM_DMFLAG_SIZE);
+                          TYPE_PULP_RV_DM ".flag", PULP_RV_DM_DMFLAG_SIZE);
     memory_region_add_subregion(&s->mem, PULP_RV_DM_DMFLAG_BASE, &s->dmflag);
     s->dmflag.disable_reentrancy_guard = true;
 
-    memory_region_init_rom_nomigrate(&s->rom, obj, TYPE_PULP_RV_DM "-rom",
+    memory_region_init_rom_nomigrate(&s->rom, obj, TYPE_PULP_RV_DM ".rom",
                                      PULP_RV_DM_ROM_SIZE, &error_abort);
     memory_region_add_subregion(&s->mem, PULP_RV_DM_ROM_BASE, &s->rom);
 

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -1796,10 +1796,10 @@ static void ot_flash_realize(DeviceState *dev, Error **errp)
 
 #if DATA_PART_USE_IO_OPS
     memory_region_init_io(mr, OBJECT(dev), &ot_flash_mem_ops, s,
-                          TYPE_OT_FLASH "-mem", size);
+                          TYPE_OT_FLASH ".mem", size);
 #else
     /* there is no "memory_region_init_rom_ptr" - use ram_ptr variant and r/o */
-    memory_region_init_ram_ptr(mr, OBJECT(dev), TYPE_OT_FLASH "-mem", size,
+    memory_region_init_ram_ptr(mr, OBJECT(dev), TYPE_OT_FLASH ".mem", size,
                                (void *)s->flash.data);
     mr->readonly = true;
 #endif /* DATA_PART_USE_IO_OPS */
@@ -1812,11 +1812,11 @@ static void ot_flash_init(Object *obj)
     OtFlashState *s = OT_FLASH(obj);
 
     memory_region_init_io(&s->mmio.regs, obj, &ot_flash_regs_ops, s,
-                          TYPE_OT_FLASH "-regs", REGS_SIZE);
+                          TYPE_OT_FLASH ".regs", REGS_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio.regs);
 
     memory_region_init_io(&s->mmio.csrs, obj, &ot_flash_csrs_ops, s,
-                          TYPE_OT_FLASH "-csrs", CSRS_SIZE);
+                          TYPE_OT_FLASH ".csrs", CSRS_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio.csrs);
 
     s->regs = g_new0(uint32_t, REGS_COUNT);

--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -609,11 +609,11 @@ static void ot_hmac_init(Object *obj)
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio);
 
     memory_region_init_io(&s->regs_mmio, obj, &ot_hmac_regs_ops, s,
-                          TYPE_OT_HMAC "-regs", REGS_SIZE);
+                          TYPE_OT_HMAC ".regs", REGS_SIZE);
     memory_region_add_subregion(&s->mmio, OT_HMAC_REGS_BASE, &s->regs_mmio);
 
     memory_region_init_io(&s->fifo_mmio, obj, &ot_hmac_fifo_ops, s,
-                          TYPE_OT_HMAC "-fifo", OT_HMAC_FIFO_SIZE);
+                          TYPE_OT_HMAC ".fifo", OT_HMAC_FIFO_SIZE);
     memory_region_add_subregion(&s->mmio, OT_HMAC_FIFO_BASE, &s->fifo_mmio);
 
     /* setup FIFO Interrupt Timer */

--- a/hw/opentitan/ot_kmac.c
+++ b/hw/opentitan/ot_kmac.c
@@ -1634,15 +1634,15 @@ static void ot_kmac_init(Object *obj)
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio);
 
     memory_region_init_io(&s->regs_mmio, obj, &ot_kmac_regs_ops, s,
-                          TYPE_OT_KMAC "-regs", REGS_SIZE);
+                          TYPE_OT_KMAC ".regs", REGS_SIZE);
     memory_region_add_subregion(&s->mmio, OT_KMAC_REGS_BASE, &s->regs_mmio);
 
     memory_region_init_io(&s->state_mmio, obj, &ot_kmac_state_ops, s,
-                          TYPE_OT_KMAC "-state", OT_KMAC_STATE_SIZE);
+                          TYPE_OT_KMAC ".state", OT_KMAC_STATE_SIZE);
     memory_region_add_subregion(&s->mmio, OT_KMAC_STATE_BASE, &s->state_mmio);
 
     memory_region_init_io(&s->msgfifo_mmio, obj, &ot_kmac_msgfifo_ops, s,
-                          TYPE_OT_KMAC "-msgfifo", OT_KMAC_MSG_FIFO_SIZE);
+                          TYPE_OT_KMAC ".msgfifo", OT_KMAC_MSG_FIFO_SIZE);
     memory_region_add_subregion(&s->mmio, OT_KMAC_MSG_FIFO_BASE,
                                 &s->msgfifo_mmio);
 

--- a/hw/opentitan/ot_otbn.c
+++ b/hw/opentitan/ot_otbn.c
@@ -657,7 +657,7 @@ static void ot_otbn_init(Object *obj)
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio);
 
     memory_region_init_io(&s->regs, obj, &ot_otbn_regs_ops, s,
-                          TYPE_OT_OTBN "-regs", REGS_SIZE);
+                          TYPE_OT_OTBN ".regs", REGS_SIZE);
     memory_region_add_subregion(&s->mmio, OT_OTBN_REGS_BASE, &s->regs);
 
     /*
@@ -665,7 +665,7 @@ static void ot_otbn_init(Object *obj)
      * controlled and checksum to be computed in-order
      */
     memory_region_init_io(&s->imem, obj, &ot_otbn_imem_ops, s,
-                          TYPE_OT_OTBN "-imem", OT_OTBN_IMEM_SIZE);
+                          TYPE_OT_OTBN ".imem", OT_OTBN_IMEM_SIZE);
     memory_region_add_subregion(&s->mmio, OT_OTBN_IMEM_BASE, &s->imem);
 
     /*
@@ -673,7 +673,7 @@ static void ot_otbn_init(Object *obj)
      * controlled and checksum to be computed in-order
      */
     memory_region_init_io(&s->dmem, obj, &ot_otbn_dmem_ops, s,
-                          TYPE_OT_OTBN "-dmem", OT_OTBN_DMEM_SIZE);
+                          TYPE_OT_OTBN ".dmem", OT_OTBN_DMEM_SIZE);
     memory_region_add_subregion(&s->mmio, OT_OTBN_DMEM_BASE, &s->dmem);
 
     ibex_sysbus_init_irq(obj, &s->irq_done);

--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -1372,21 +1372,21 @@ static void ot_otp_eg_init(Object *obj)
 {
     OtOTPEgState *s = OT_OTP_EG(obj);
 
-    memory_region_init(&s->mmio.ctrl, obj, TYPE_OT_OTP "-ctrl", 0x2000u);
+    memory_region_init(&s->mmio.ctrl, obj, TYPE_OT_OTP ".ctrl", 0x2000u);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio.ctrl);
 
     memory_region_init_io(&s->mmio.sub.regs, obj, &ot_otp_eg_regs_ops, s,
-                          TYPE_OT_OTP "-regs", REGS_SIZE);
+                          TYPE_OT_OTP ".regs", REGS_SIZE);
     memory_region_add_subregion(&s->mmio.ctrl, 0u, &s->mmio.sub.regs);
 
     /* TODO: it might be worthwhile to use a ROM-kind here */
     memory_region_init_io(&s->mmio.sub.swcfg, obj, &ot_otp_eg_swcfg_ops, s,
-                          TYPE_OT_OTP "-swcfg", SW_CFG_WINDOW_SIZE);
+                          TYPE_OT_OTP ".swcfg", SW_CFG_WINDOW_SIZE);
     memory_region_add_subregion(&s->mmio.ctrl, SW_CFG_WINDOW,
                                 &s->mmio.sub.swcfg);
 
     memory_region_init_io(&s->prim.csrs, obj, &ot_otp_eg_csrs_ops, s,
-                          TYPE_OT_OTP "-prim", CSRS_SIZE);
+                          TYPE_OT_OTP ".prim", CSRS_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->prim.csrs);
 
     for (unsigned ix = 0; ix < ARRAY_SIZE(s->irqs); ix++) {

--- a/hw/opentitan/ot_rom_ctrl.c
+++ b/hw/opentitan/ot_rom_ctrl.c
@@ -572,7 +572,7 @@ static void ot_rom_ctrl_realize(DeviceState *dev, Error **errp)
 
     memory_region_init_rom_device_nomigrate(&s->mem, OBJECT(dev),
                                             &ot_rom_ctrl_mem_ops, s,
-                                            TYPE_OT_ROM_CTRL "-mem", s->size,
+                                            TYPE_OT_ROM_CTRL ".mem", s->size,
                                             errp);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mem);
 
@@ -595,7 +595,7 @@ static void ot_rom_ctrl_init(Object *obj)
     ibex_qdev_init_irq(obj, &s->pwrmgr_done, OT_ROM_CTRL_DONE);
 
     memory_region_init_io(&s->mmio, obj, &ot_rom_ctrl_regs_ops, s,
-                          TYPE_OT_ROM_CTRL "-regs", REGS_SIZE);
+                          TYPE_OT_ROM_CTRL ".regs", REGS_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio);
 
     ibex_qdev_init_irq(obj, &s->alert, OT_DEVICE_ALERT);

--- a/hw/opentitan/ot_spi_device.c
+++ b/hw/opentitan/ot_spi_device.c
@@ -2631,19 +2631,19 @@ static void ot_spi_device_init(Object *obj)
     SpiDeviceFlash *f = &s->flash;
     SpiDeviceBus *bus = &s->bus;
 
-    memory_region_init(&s->mmio.main, obj, TYPE_OT_SPI_DEVICE "-mmio",
+    memory_region_init(&s->mmio.main, obj, TYPE_OT_SPI_DEVICE ".mmio",
                        SPI_DEVICE_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio.main);
     memory_region_init_io(&s->mmio.spi, obj, &ot_spi_device_spi_regs_ops, s,
-                          TYPE_OT_SPI_DEVICE "-spi-regs", SPI_REGS_SIZE);
+                          TYPE_OT_SPI_DEVICE ".spi-regs", SPI_REGS_SIZE);
     memory_region_add_subregion(&s->mmio.main, SPI_DEVICE_SPI_REGS_OFFSET,
                                 &s->mmio.spi);
     memory_region_init_io(&s->mmio.tpm, obj, &ot_spi_device_tpm_regs_ops, s,
-                          TYPE_OT_SPI_DEVICE "-tpm-regs", TPM_REGS_SIZE);
+                          TYPE_OT_SPI_DEVICE ".tpm-regs", TPM_REGS_SIZE);
     memory_region_add_subregion(&s->mmio.main, SPI_DEVICE_TPM_REGS_OFFSET,
                                 &s->mmio.tpm);
     memory_region_init_io(&s->mmio.buf, obj, &ot_spi_device_buf_ops, s,
-                          TYPE_OT_SPI_DEVICE "-buf", SRAM_SIZE);
+                          TYPE_OT_SPI_DEVICE ".buf", SRAM_SIZE);
     memory_region_add_subregion(&s->mmio.main, SPI_DEVICE_SRAM_OFFSET,
                                 &s->mmio.buf);
 

--- a/hw/opentitan/ot_sram_ctrl.c
+++ b/hw/opentitan/ot_sram_ctrl.c
@@ -680,7 +680,7 @@ static void ot_sram_ctrl_realize(DeviceState *dev, Error **errp)
          * uninitialized and should not be used.
          */
         memory_region_init_ram_nomigrate(&s->mem->sram, OBJECT(dev),
-                                         TYPE_OT_SRAM_CTRL "-mem", size, errp);
+                                         TYPE_OT_SRAM_CTRL ".mem", size, errp);
         sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mem->sram);
 
         return;
@@ -717,9 +717,9 @@ static void ot_sram_ctrl_realize(DeviceState *dev, Error **errp)
 
     memory_region_init_io(&s->mem->init, OBJECT(dev),
                           &ot_sram_ctrl_mem_init_ops, s,
-                          TYPE_OT_SRAM_CTRL "-mem-init", size);
+                          TYPE_OT_SRAM_CTRL ".mem.init", size);
     memory_region_init_ram_nomigrate(&s->mem->sram, OBJECT(dev),
-                                     TYPE_OT_SRAM_CTRL "-mem-sram", size, errp);
+                                     TYPE_OT_SRAM_CTRL ".mem.sram", size, errp);
 
     /*
      * use an alias than points to the currently selected RAM backend, either
@@ -732,7 +732,7 @@ static void ot_sram_ctrl_realize(DeviceState *dev, Error **errp)
      * object while changing its actual backend on initialization demand.
      */
     memory_region_init_alias(&s->mem->alias, OBJECT(dev),
-                             TYPE_OT_SRAM_CTRL "-mem", &s->mem->init, 0, size);
+                             TYPE_OT_SRAM_CTRL ".mem", &s->mem->init, 0, size);
     /*
      * at start up, the SRAM memory is aliased to the I/O backend, so that
      * access can be controlled
@@ -745,7 +745,7 @@ static void ot_sram_ctrl_init(Object *obj)
     OtSramCtrlState *s = OT_SRAM_CTRL(obj);
 
     memory_region_init_io(&s->mmio, obj, &ot_sram_ctrl_regs_ops, s,
-                          TYPE_OT_SRAM_CTRL "-regs", REGS_SIZE);
+                          TYPE_OT_SRAM_CTRL ".regs", REGS_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio);
 
     ibex_qdev_init_irq(obj, &s->alert, OT_DEVICE_ALERT);

--- a/hw/riscv/ibex_common.c
+++ b/hw/riscv/ibex_common.c
@@ -516,7 +516,7 @@ void ibex_identify_devices(DeviceState **devices, const char *id_prop,
 
         bool res;
         if (is_set && id_prepend) {
-            char *pvalue = g_strconcat(id_value, value, NULL);
+            char *pvalue = g_strconcat(id_value, ".", value, NULL);
             res = object_property_set_str(obj, id_prop, pvalue, NULL);
             g_free(pvalue);
         } else {

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -817,28 +817,28 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         ),
     },
     [OT_DJ_SOC_DEV_MBX0] = {
-        OT_DJ_SOC_DEV_MBX(0, 0x22000000u, "ot-mbx-sram", 134, 75),
+        OT_DJ_SOC_DEV_MBX(0, 0x22000000u, "ot-mbx.sram", 134, 75),
     },
     [OT_DJ_SOC_DEV_MBX1] = {
-        OT_DJ_SOC_DEV_MBX(1, 0x22000100u, "ot-mbx-sram", 137, 77),
+        OT_DJ_SOC_DEV_MBX(1, 0x22000100u, "ot-mbx.sram", 137, 77),
     },
     [OT_DJ_SOC_DEV_MBX2] = {
-        OT_DJ_SOC_DEV_MBX(2, 0x22000200u, "ot-mbx-sram", 140, 79),
+        OT_DJ_SOC_DEV_MBX(2, 0x22000200u, "ot-mbx.sram", 140, 79),
     },
     [OT_DJ_SOC_DEV_MBX3] = {
-        OT_DJ_SOC_DEV_MBX(3, 0x22000300u, "ot-mbx-sram", 143, 81),
+        OT_DJ_SOC_DEV_MBX(3, 0x22000300u, "ot-mbx.sram", 143, 81),
     },
     [OT_DJ_SOC_DEV_MBX4] = {
-        OT_DJ_SOC_DEV_MBX(4, 0x22000400u, "ot-mbx-sram", 146, 83),
+        OT_DJ_SOC_DEV_MBX(4, 0x22000400u, "ot-mbx.sram", 146, 83),
     },
     [OT_DJ_SOC_DEV_MBX5] = {
-        OT_DJ_SOC_DEV_MBX(5, 0x22000500u, "ot-mbx-sram", 149, 85),
+        OT_DJ_SOC_DEV_MBX(5, 0x22000500u, "ot-mbx.sram", 149, 85),
     },
     [OT_DJ_SOC_DEV_MBX6] = {
-        OT_DJ_SOC_DEV_MBX(6, 0x22000600u, "ot-mbx-sram", 152, 87),
+        OT_DJ_SOC_DEV_MBX(6, 0x22000600u, "ot-mbx.sram", 152, 87),
     },
     [OT_DJ_SOC_DEV_MBX_JTAG] = {
-        OT_DJ_SOC_DEV_MBX_DUAL(7, 0x22000800u, "ot-mbx-sram", 155, 89,
+        OT_DJ_SOC_DEV_MBX_DUAL(7, 0x22000800u, "ot-mbx.sram", 155, 89,
 		                       DEBUG_MEMORY(OT_DJ_DEBUG_MBX_JTAG_ADDR)),
     },
     [OT_DJ_SOC_DEV_DMA] = {
@@ -931,10 +931,10 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         ),
     },
     [OT_DJ_SOC_DEV_MBX_PCIE0] = {
-        OT_DJ_SOC_DEV_MBX(8, 0x22040000u, "ot-mbx-sram", 158, 91),
+        OT_DJ_SOC_DEV_MBX(8, 0x22040000u, "ot-mbx.sram", 158, 91),
     },
     [OT_DJ_SOC_DEV_MBX_PCIE1] = {
-        OT_DJ_SOC_DEV_MBX(9, 0x22040100u, "ot-mbx-sram", 161, 93),
+        OT_DJ_SOC_DEV_MBX(9, 0x22040100u, "ot-mbx.sram", 161, 93),
     },
     [OT_DJ_SOC_DEV_PLIC] = {
         .type = TYPE_SIFIVE_PLIC,
@@ -1553,12 +1553,12 @@ static void ot_dj_soc_realize(DeviceState *dev, Error **errp)
 
     Object *oas;
 
-    oas = object_property_get_link(OBJECT(s)->parent, "ctn-as", errp);
+    oas = object_property_get_link(OBJECT(s)->parent, "ctn.as", errp);
     g_assert(oas);
     AddressSpace *ctn_as = ot_address_space_get(OT_ADDRESS_SPACE(oas));
 
     MemoryRegion *dbg_mr = g_new0(MemoryRegion, 1u);
-    memory_region_init(dbg_mr, OBJECT(dev), "dbg-xbar", OT_DJ_DBG_XBAR_SIZE);
+    memory_region_init(dbg_mr, OBJECT(dev), "dbg.xbar", OT_DJ_DBG_XBAR_SIZE);
 
     MemoryRegion *mrs[IBEX_MEMMAP_REGIDX_COUNT] = {
         [OT_DJ_DEFAULT_MEMORY_REGION] = cpu->memory,
@@ -1573,24 +1573,24 @@ static void ot_dj_soc_realize(DeviceState *dev, Error **errp)
                                   OT_DJ_DEBUG_MEMORY_REGION));
 
     MemoryRegion *mbx_sram_root_mr = g_new0(MemoryRegion, 1u);
-    memory_region_init(mbx_sram_root_mr, OBJECT(s), "mbx-sram-root",
+    memory_region_init(mbx_sram_root_mr, OBJECT(s), "mbx.sram",
                        OT_DJ_PRIVATE_REGION_SIZE);
     AddressSpace *mbx_sram_as = g_new0(AddressSpace, 1u);
-    address_space_init(mbx_sram_as, mbx_sram_root_mr, "mbx_sram-as");
+    address_space_init(mbx_sram_as, mbx_sram_root_mr, "mbx.sram.as");
     Object *mbx_sram_oas = object_new(TYPE_OT_ADDRESS_SPACE);
-    object_property_add_child(OBJECT(dev), "ot-mbx-sram", mbx_sram_oas);
+    object_property_add_child(OBJECT(dev), "ot-mbx.sram", mbx_sram_oas);
     ot_address_space_set(OT_ADDRESS_SPACE(mbx_sram_oas), mbx_sram_as);
     SysBusDevice *sram_dev = SYS_BUS_DEVICE(s->devices[OT_DJ_SOC_DEV_SRAM_MBX]);
     /* first MMIO maps to register, second MMIO maps to SRAM */
     MemoryRegion *mbx_sram_mr = sysbus_mmio_get_region(sram_dev, 1);
     MemoryRegion *mbx_sram_alias_mr = g_new0(MemoryRegion, 1u);
-    memory_region_init_alias(mbx_sram_alias_mr, OBJECT(s), "mbx-sram",
+    memory_region_init_alias(mbx_sram_alias_mr, OBJECT(s), "mbx.sram",
                              mbx_sram_mr, 0u, int128_getlo(mbx_sram_mr->size));
     memory_region_add_subregion(mbx_sram_root_mr, mbx_sram_mr->addr,
                                 mbx_sram_alias_mr);
 
     AddressSpace *dbg_as = g_new0(AddressSpace, 1u);
-    address_space_init(dbg_as, dbg_mr, "dbg-as");
+    address_space_init(dbg_as, dbg_mr, "dbg.as");
 
     oas = object_new(TYPE_OT_ADDRESS_SPACE);
     object_property_add_child(OBJECT(dev), "ot-dbg", oas);
@@ -1607,16 +1607,16 @@ static void ot_dj_soc_realize(DeviceState *dev, Error **errp)
      * range is kept empty
      */
     MemoryRegion *ctn_dma_mr = g_new0(MemoryRegion, 1u);
-    memory_region_init(ctn_dma_mr, OBJECT(dev), "ctn-dma",
+    memory_region_init(ctn_dma_mr, OBJECT(dev), "ctn.dma",
                        OT_DJ_CTN_REGION_OFFSET + OT_DJ_CTN_REGION_SIZE);
 
     /* create an AS view for this new root region */
     AddressSpace *ctn_dma_as = g_new0(AddressSpace, 1u);
-    address_space_init(ctn_dma_as, ctn_dma_mr, "ctn-dma-as");
+    address_space_init(ctn_dma_as, ctn_dma_mr, "ctn.dma.as");
 
     /* create and map an alias to the CTN MR into the elevated region */
     MemoryRegion *ctn_amr = g_new0(MemoryRegion, 1u);
-    memory_region_init_alias(ctn_amr, OBJECT(dev), "ctn-dma-alias",
+    memory_region_init_alias(ctn_amr, OBJECT(dev), "ctn.dma.alias",
                              ctn_as->root, 0u, (uint64_t)OT_DJ_CTN_REGION_SIZE);
     memory_region_add_subregion(ctn_dma_mr, (hwaddr)OT_DJ_CTN_REGION_OFFSET,
                                 ctn_amr);
@@ -1688,12 +1688,12 @@ static void ot_dj_board_realize(DeviceState *dev, Error **errp)
 
     /* CTN memory region */
     MemoryRegion *ctn_mr = g_new0(MemoryRegion, 1u);
-    memory_region_init(ctn_mr, OBJECT(dev), "ctn-xbar",
+    memory_region_init(ctn_mr, OBJECT(dev), "ctn.xbar",
                        (uint64_t)OT_DJ_CTN_REGION_SIZE);
 
     /* CTN address space */
     AddressSpace *ctn_as = g_new0(AddressSpace, 1);
-    address_space_init(ctn_as, ctn_mr, "ctn-as");
+    address_space_init(ctn_as, ctn_mr, "ctn.as");
     Object *oas = object_new(TYPE_OT_ADDRESS_SPACE);
     object_property_add_child(OBJECT(dev), ctn_as->name, oas);
     ot_address_space_set(OT_ADDRESS_SPACE(oas), ctn_as);
@@ -1705,13 +1705,13 @@ static void ot_dj_board_realize(DeviceState *dev, Error **errp)
 
     /* CTN RAM */
     MemoryRegion *ctn_ram = g_new0(MemoryRegion, 1u);
-    memory_region_init_ram_nomigrate(ctn_ram, OBJECT(s), "ctn-ram",
+    memory_region_init_ram_nomigrate(ctn_ram, OBJECT(s), "ctn.ram",
                                      OT_DJ_CTN_RAM_SIZE, errp);
     memory_region_add_subregion(ctn_mr, OT_DJ_CTN_RAM_ADDR, ctn_ram);
 
     /* CTN aliased memory in CPU address space */
     MemoryRegion *ctn_alias_mr = g_new0(MemoryRegion, 1u);
-    memory_region_init_alias(ctn_alias_mr, OBJECT(dev), "ctn-alias", ctn_mr, 0u,
+    memory_region_init_alias(ctn_alias_mr, OBJECT(dev), "ctn.alias", ctn_mr, 0u,
                              (uint64_t)OT_DJ_CTN_REGION_SIZE);
     memory_region_add_subregion(get_system_memory(),
                                 (hwaddr)OT_DJ_CTN_REGION_OFFSET, ctn_alias_mr);

--- a/include/hw/riscv/ibex_common.h
+++ b/include/hw/riscv/ibex_common.h
@@ -157,6 +157,7 @@ typedef struct {
 
 typedef struct IbexMemMapEntry {
     hwaddr base;
+    int8_t priority;
 } IbexMemMapEntry;
 
 /* Device definition */

--- a/scripts/opentitan/pyot.py
+++ b/scripts/opentitan/pyot.py
@@ -1207,10 +1207,11 @@ class QEMUExecuter:
             args.machine
         ]
         rom_exec = bool(args.rom_exec)
-        multi_rom = (len(args.rom) + int(rom_exec)) > 1
+        roms = args.rom or []
+        multi_rom = (len(roms) + int(rom_exec)) > 1
         # generate pre-application ROM option
         rom_count = 0
-        for rom in args.rom:
+        for rom in roms:
             rom_path = self._qfm.interpolate(rom)
             if not isfile(rom_path):
                 raise ValueError(f'Unable to find ROM file {rom_path}')

--- a/scripts/opentitan/pyot.py
+++ b/scripts/opentitan/pyot.py
@@ -1216,7 +1216,7 @@ class QEMUExecuter:
                 raise ValueError(f'Unable to find ROM file {rom_path}')
             rom_ids = []
             if args.first_soc:
-                rom_ids.append(args.first_soc)
+                rom_ids.append(f'{args.first_soc}.')
             rom_ids.append('rom')
             if multi_rom:
                 rom_ids.append(f'{rom_count}')
@@ -1239,7 +1239,7 @@ class QEMUExecuter:
                     # generate ROM option for the application itself
                     rom_ids = []
                     if args.first_soc:
-                        rom_ids.append(args.first_soc)
+                        rom_ids.append(f'{args.first_soc}.')
                     rom_ids.append('rom')
                     if multi_rom:
                         rom_ids.append(f'{rom_count}')

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -1294,7 +1294,8 @@ static void riscv_cpu_set_irq(void *opaque, int irq, int level)
             }
             break;
         default:
-            g_assert_not_reached();
+            /* Handle platform / custom local interrupts */
+            riscv_cpu_update_mip(env, 1ULL << irq, BOOL_TO_MASK(level));
         }
     } else if (irq < (IRQ_LOCAL_MAX + IRQ_LOCAL_GUEST_MAX)) {
         /* Require H-extension for handling guest local interrupts */

--- a/target/riscv/cpu_bits.h
+++ b/target/riscv/cpu_bits.h
@@ -726,7 +726,8 @@ typedef enum RISCVException {
 #define IRQ_M_EXT                          11
 #define IRQ_S_GEXT                         12
 #define IRQ_PMU_OVF                        13
-#define IRQ_LOCAL_MAX                      16
+#define IRQ_LOCAL_MAX                      64
+/* -1 is due to bit zero of hgeip and hgeie being ROZ. */
 #define IRQ_LOCAL_GUEST_MAX                (TARGET_LONG_BITS - 1)
 
 /* mip masks */

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -1189,18 +1189,18 @@ static const target_ulong sstatus_v1_10_mask = SSTATUS_SIE | SSTATUS_SPIE |
  */
 
 /* Bit STIP can be an alias of mip.STIP that's why it's writable in mvip. */
-static const target_ulong mvip_writable_mask = MIP_SSIP | MIP_STIP | MIP_SEIP |
+static const uint64_t mvip_writable_mask = MIP_SSIP | MIP_STIP | MIP_SEIP |
                                     LOCAL_INTERRUPTS;
-static const target_ulong mvien_writable_mask = MIP_SSIP | MIP_SEIP |
+static const uint64_t mvien_writable_mask = MIP_SSIP | MIP_SEIP |
                                     LOCAL_INTERRUPTS;
 
-static const target_ulong sip_writable_mask = SIP_SSIP | LOCAL_INTERRUPTS;
-static const target_ulong hip_writable_mask = MIP_VSSIP;
-static const target_ulong hvip_writable_mask = MIP_VSSIP | MIP_VSTIP |
+static const uint64_t sip_writable_mask = SIP_SSIP | LOCAL_INTERRUPTS;
+static const uint64_t hip_writable_mask = MIP_VSSIP;
+static const uint64_t hvip_writable_mask = MIP_VSSIP | MIP_VSTIP |
                                     MIP_VSEIP | LOCAL_INTERRUPTS;
-static const target_ulong hvien_writable_mask = LOCAL_INTERRUPTS;
+static const uint64_t hvien_writable_mask = LOCAL_INTERRUPTS;
 
-static const target_ulong vsip_writable_mask = MIP_VSSIP | LOCAL_INTERRUPTS;
+static const uint64_t vsip_writable_mask = MIP_VSSIP | LOCAL_INTERRUPTS;
 
 const bool valid_vm_1_10_32[16] = {
     [VM_1_10_MBARE] = true,

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -1137,8 +1137,7 @@ static RISCVException write_stimecmph(CPURISCVState *env, int csrno,
 
 #define VSTOPI_NUM_SRCS 5
 
-#define LOCAL_INTERRUPTS   ((((uint64_t)1 << IRQ_LOCAL_GUEST_MAX) - 1) & \
-                            ~(((uint64_t)1 << IRQ_LOCAL_MAX) - 1))
+#define LOCAL_INTERRUPTS (~0x1FFF)
 
 static const uint64_t delegable_ints =
     S_MODE_INTERRUPTS | VS_MODE_INTERRUPTS | MIP_LCOFIP;
@@ -1550,10 +1549,7 @@ static RISCVException rmw_mie64(CPURISCVState *env, int csrno,
                                 uint64_t *ret_val,
                                 uint64_t new_val, uint64_t wr_mask)
 {
-    uint64_t mask;
-
-    mask = wr_mask & (riscv_has_ext(env, RVH) ?
-            all_ints : (all_ints | LOCAL_INTERRUPTS));
+    uint64_t mask = wr_mask & all_ints;
 
     if (ret_val) {
         *ret_val = env->mie;

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -1137,7 +1137,14 @@ static RISCVException write_stimecmph(CPURISCVState *env, int csrno,
 
 #define VSTOPI_NUM_SRCS 5
 
-#define LOCAL_INTERRUPTS (~0x1FFF)
+/*
+ * All core local interrupts except the fixed ones 0:12. This macro is for
+ * virtual interrupts logic so please don't change this to avoid messing up
+ * the whole support, For reference see AIA spec: `5.3 Interrupt filtering and
+ * virtual interrupts for supervisor level` and `6.3.2 Virtual interrupts for
+ * VS level`.
+ */
+#define LOCAL_INTERRUPTS   (~0x1FFFULL)
 
 static const uint64_t delegable_ints =
     S_MODE_INTERRUPTS | VS_MODE_INTERRUPTS | MIP_LCOFIP;


### PR DESCRIPTION
Mainly some clean-up patches to get easier to read memory region names in QEMU monitor + 1 fix for interrupts on `ibexdemo` machine.