### PR TITLE
ci: bump release build to ubuntu-22.04

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -15,7 +15,7 @@ jobs:
       BUILD_DIR: build
       BRANCH_NAME: ${{ github.event.repository.default_branch }}
       RELEASE_BIN_ARCHIVE: qemu-ot-earlgrey-${{ inputs.release_tag }}-x86_64-unknown-linux-gnu.tar.gz
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - name: Check out repository

--- a/scripts/opentitan/make_release.sh
+++ b/scripts/opentitan/make_release.sh
@@ -18,4 +18,5 @@ QEMU_BUILD="$3"
 tar --create --auto-compress --verbose --file="$OUT_TARBALL" \
     --directory="$QEMU_DIR" \
     "$QEMU_BUILD"/qemu-{system-riscv32,img} \
-    scripts/opentitan/{otpconv,flashgen}.py
+    scripts/opentitan/{otptool,flashgen}.py \
+    python/qemu/ot


### PR DESCRIPTION
Required to get the necessary `glib` version required for QEMU (>=2.66.0).

Note that binaries built from `ubuntu-22.04` will no longer be usable from `ubuntu-20.04` due to `glibc` incompatibility.