### PR TITLE
[ot] Update CSRNG `SW_CMD_STS.CMD_RDY`

### DIFF
--- a/hw/opentitan/ot_csrng.c
+++ b/hw/opentitan/ot_csrng.c
@@ -908,6 +908,7 @@ static void ot_csrng_handle_enable(OtCSRNGState *s)
             xtrace_ot_csrng_info("enable: no ES gen tracking", gennum);
         }
         s->enabled = true;
+        s->regs[R_SW_CMD_STS] |= R_SW_CMD_STS_CMD_RDY_MASK;
         s->es_retry_count = ENTROPY_SRC_INITIAL_REQUEST_COUNT;
         s->entropy_gennum = gennum;
     }
@@ -934,6 +935,7 @@ static void ot_csrng_handle_enable(OtCSRNGState *s)
             }
         }
         s->enabled = false;
+        s->regs[R_SW_CMD_STS] &= ~R_SW_CMD_STS_CMD_RDY_MASK;
         s->es_retry_count = 0;
         s->entropy_gennum = cls->get_random_generation(randif);
         xtrace_ot_csrng_info("disable: last RS generation", s->entropy_gennum);


### PR DESCRIPTION
`CMD_RDY` is gated on `CTRL.ENABLE` since OT commit 042e0b9158.

This change is needed to, for instance, make `csrng_send_app_cmd` progress when it loops waiting for the "status register to be ready to accept the next command."

This change allows csrng_smoketest from Earlgrey 1.0 to pass.