### PR TITLE
[ot] hw/opentitan: fix clang-format in ot_otp_eg_parts.c

### DIFF
--- a/hw/opentitan/ot_otp_eg_parts.c
+++ b/hw/opentitan/ot_otp_eg_parts.c
@@ -1,5 +1,8 @@
 /* Generated from otp_ctrl_mmap.hjson with otptool.py */
 
+/* this prevents linters from checking this file without its parent file */
+#ifdef OT_OTP_EG_PARTS
+
 /* clang-format off */
 /* NOLINTBEGIN */
 static const OtOTPPartDesc OtOTPPartDescs[] = {
@@ -147,3 +150,5 @@ static const OtOTPPartDesc OtOTPPartDescs[] = {
 
 /* NOLINTEND */
 /* clang-format on */
+
+#endif /* OT_OTP_EG_PARTS */


### PR DESCRIPTION
Accidentally deleted this ifdef in a previous commit.