### PR TITLE
Add HMAC stop/continue commands & endian swaps

### DIFF
--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -762,11 +762,14 @@ static void ot_hmac_realize(DeviceState *dev, Error **errp)
 static void ot_hmac_reset(DeviceState *dev)
 {
     OtHMACState *s = OT_HMAC(dev);
+    OtHMACRegisters *r = s->regs;
 
     ibex_irq_set(&s->clkmgr, false);
 
     memset(s->ctx, 0, sizeof(*(s->ctx)));
     memset(s->regs, 0, sizeof(*(s->regs)));
+
+    r->cfg = 0x4100u;
 
     ot_hmac_update_irqs(s);
     ot_hmac_update_alert(s);

--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -486,6 +486,9 @@ static uint64_t ot_hmac_regs_read(void *opaque, hwaddr addr, unsigned size)
                 val32 |= R_STATUS_FIFO_FULL_MASK;
             }
         }
+        if (!(s->regs->cmd)) {
+            val32 |= R_STATUS_HMAC_IDLE_MASK;
+        }
     } break;
     case R_ERR_CODE:
         val32 = s->regs->err_code;
@@ -610,8 +613,10 @@ static void ot_hmac_regs_write(void *opaque, hwaddr addr, uint64_t value,
         }
 
         s->regs->cfg =
-            val32 & (R_CFG_HMAC_EN_MASK | R_CFG_SHA_EN_MASK |
-                     R_CFG_ENDIAN_SWAP_MASK | R_CFG_DIGEST_SWAP_MASK);
+            val32 &
+            (R_CFG_HMAC_EN_MASK | R_CFG_SHA_EN_MASK | R_CFG_ENDIAN_SWAP_MASK |
+             R_CFG_DIGEST_SWAP_MASK | R_CFG_KEY_SWAP_MASK |
+             R_CFG_DIGEST_SIZE_MASK | R_CFG_KEY_LENGTH_MASK);
 
         /* clear digest when SHA is disabled */
         if (!(s->regs->cfg & R_CFG_SHA_EN_MASK)) {


### PR DESCRIPTION
This PR partially updates Earlgrey's HMAC to match the latest hardware interface changes. It adds digest write-back during SHA256 processing to allow for saving and restoring of partial hash context, adds support for the `Stop`/`Continue` commands used to do this, and updates the supporting message length and digest registers. It also implements the new key/digest swap config fields, and makes a couple other small fixes. See the commit messages for more details.
**Note:** the first commit 77322d9c7d9af690674ed2abebf8542d509f2a8d is taken from #86, as that applies to the HMAC and is required for functional operation.

Tested against existing passing tests `hmac_enc_idle_test` and `hmac_smoketest` and previously failing test `wots_test` from [`master`](https://github.com/lowrisc/opentitan/commits/b70973d2e9a3705361425d59a5e64a660b6fe1fc) on OpenTitan.