### PR TITLE
Add HMAC multi-mode support (SHA-2 384/512 digest sizes and variable key lengths)

### DIFF
--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -683,7 +683,10 @@ static void ot_hmac_regs_write(void *opaque, hwaddr addr, uint64_t value,
         if (val32 & R_CMD_HASH_STOP_MASK) {
             s->regs->cmd = R_CMD_HASH_STOP_MASK;
 
-            /* trigger delayed processing of FIFO until the next block is processed. */
+            /*
+             * trigger delayed processing of FIFO until the next block is
+             * processed.
+             */
             ibex_irq_set(&s->clkmgr, true);
             ot_hmac_process_fifo(s);
         }
@@ -716,7 +719,6 @@ static void ot_hmac_regs_write(void *opaque, hwaddr addr, uint64_t value,
 
         break;
     case R_WIPE_SECRET:
-        /* TODO ignore write if engine is not idle? */
         s->regs->wipe_secret = val32;
         ot_hmac_wipe_buffer(s, s->regs->key, ARRAY_SIZE(s->regs->key));
         ot_hmac_wipe_buffer(s, s->regs->digest, ARRAY_SIZE(s->regs->digest));

--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -2,9 +2,11 @@
  * QEMU OpenTitan HMAC device
  *
  * Copyright (c) 2022-2024 Rivos, Inc.
+ * Copyright (c) 2024 lowRISC contributors.
  *
  * Author(s):
  *  Loïc Lefort <loic@rivosinc.com>
+ *  Alex Jones <alex.jones@lowrisc.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR completes the remaining work to get Earlgrey's HMAC to match the latest hardware functionality. May be easier to review commit-by-commit. See commit messages for more details.

Adds support to the HMAC for variable digest sizes (SHA-2 256/384/512) and key lengths (128/256/384/512/1024 bits) by setting the corresponding fields in the config register. Related checks are added, and existing functionality replaced which assumed SHA-2 256 & key size <= 512 bits. Also cleans up the last minor TODO.

Tested against existing passing tests: `hmac_enc_test`, `hmac_sha256_functest`, `sha256_functest`, `hmac_smoketest`, `wots_test`, `verify_test_hardcoded`, `fors_test`, etc.
Also tested to now make previously failing tests pass: `hmac_functest`, `sha384_functest`, `hmac_sha384_functest`, `sha512_functest` and `hmac_sha512_functest`.
All tests were built from [master](https://github.com/lowrisc/opentitan/commits/37fc765a852e618a202a40d24a33659cfe449580) on OpenTitan.