### PR TITLE
Compute OTBN checksum over LE values.

### DIFF
--- a/hw/opentitan/ot_otbn.c
+++ b/hw/opentitan/ot_otbn.c
@@ -523,10 +523,9 @@ static void ot_otbn_update_checksum(OtOTBNState *s, bool doi, uint32_t addr,
 {
     uint8_t buf[6];
 
-    /* BE or LE? */
-    stw_be_p(&buf[0], addr >> 2U);
-    buf[0] |= doi ? 0x80u : 0x00u;
-    stl_be_p(&buf[2], value);
+    stw_le_p(&buf[4], addr >> 2U);
+    buf[5] |= doi ? 0x80u : 0x00u;
+    stl_le_p(&buf[0], value);
 
     s->load_checksum = crc32(s->load_checksum, buf, sizeof(buf));
 }


### PR DESCRIPTION
This PR fixes the OTBN checksum computation. The OTBN checksum is currently being computed over big-endian order 48-bit values `{imem, addr, value}`, but the CRC32 checksum of an OTBN application is actually computed over the values in little-endian order. This PR replaces the existing Big Endian logic with Little Endian so that the computed checksum is correct.

This change has been tested to make the following tests (which were previously failing) pass: `ecdsa_p256_verify_functest_hardcoded`, `entropy_src_ast_rng_req_test`, `rnd_functest`, `rsa_3072_verify_functest_hardcoded` and `rv_core_ibex_rnd_test`. All tests were built from [master](https://github.com/lowRISC/opentitan/commits/47af8f614db155dea5543e849fa502269f91edee) on OpenTitan.