### PR TITLE
ot_aes: fix IV and CTR issues (cherry-pick #98)

### DIFF
--- a/hw/opentitan/ot_aes.c
+++ b/hw/opentitan/ot_aes.c
@@ -122,7 +122,7 @@ REG32(STATUS, 0x84u)
 
 #define OT_AES_DATA_SIZE (PARAM_NUM_REGS_DATA * sizeof(uint32_t))
 #define OT_AES_KEY_SIZE  (PARAM_NUM_REGS_KEY * sizeof(uint32_t))
-#define OT_AES_IV_SIZE   (PARAM_NUM_REGS_KEY * sizeof(uint32_t))
+#define OT_AES_IV_SIZE   (PARAM_NUM_REGS_IV * sizeof(uint32_t))
 
 /* arbitrary value long enough to give back execution to vCPU */
 #define OT_AES_RETARD_DELAY_NS 10000u /* 10 us */

--- a/hw/opentitan/ot_aes.c
+++ b/hw/opentitan/ot_aes.c
@@ -1009,7 +1009,7 @@ static uint64_t ot_aes_read(void *opaque, hwaddr addr, unsigned size)
     case R_IV_1:
     case R_IV_2:
     case R_IV_3:
-        val32 = r->keyshare[reg - R_IV_0];
+        val32 = r->iv[reg - R_IV_0];
         break;
     case R_DATA_OUT_0:
     case R_DATA_OUT_1:


### PR DESCRIPTION
This is a cherry-pick of PR #98, that fixes reading the IV registers and properly incrementing the IV values.

To make the OT `aes_test.c` test pass there is an additional fix required, to not clear (randomize) the IV register. I'll make a follow-up PR.