### PR TITLE
Update OTP constant SV file location in `cfggen.py`

### DIFF
--- a/scripts/opentitan/cfggen.py
+++ b/scripts/opentitan/cfggen.py
@@ -285,7 +285,8 @@ def main():
             argparser.error(f"No such file '{lcpath}'")
 
         if not args.otpconst:
-            ocpath = joinpath(ot_dir, 'hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv')
+            ocpath = joinpath(ot_dir, 'hw', top,
+                              'ip_autogen/otp_ctrl/rtl/otp_ctrl_part_pkg.sv')
         else:
             ocpath = args.otpconst
         if not isfile(lcpath):


### PR DESCRIPTION
After changes in OpenTitan to move otp_ctrl to ipgen, to keep QEMU working with OT's `master` we need to source the OTP constant SV file from the correct location. This default location is top-specific.