### PR TITLE
[ot] hw/opentitan: ot_aes: fix IV updates in CFB mode

### DIFF
--- a/hw/opentitan/ot_aes.c
+++ b/hw/opentitan/ot_aes.c
@@ -2,6 +2,7 @@
  * QEMU OpenTitan AES device
  *
  * Copyright (c) 2022-2024 Rivos, Inc.
+ * Copyright (c) 2025 lowRISC contributors.
  *
  * Author(s):
  *  Emmanuel Blot <eblot@rivosinc.com>
@@ -430,9 +431,11 @@ static void ot_aes_init_keyshare(OtAESState *s, bool randomize)
     OtAESRegisters *r = s->regs;
     OtAESContext *c = s->ctx;
 
-    trace_ot_aes_init("keyshare");
     if (randomize) {
+        trace_ot_aes_init("keyshare init (randomize data)");
         ot_aes_randomize(s, r->keyshare, ARRAY_SIZE(r->keyshare));
+    } else {
+        trace_ot_aes_init("keyshare init (data preserved)");
     }
     bitmap_zero(r->keyshare_bm, (int64_t)(PARAM_NUM_REGS_KEY * 2u));
     c->key_ready = false;
@@ -443,9 +446,11 @@ static void ot_aes_init_iv(OtAESState *s, bool randomize)
     OtAESRegisters *r = s->regs;
     OtAESContext *c = s->ctx;
 
-    trace_ot_aes_init("iv");
     if (randomize) {
+        trace_ot_aes_init("iv init (randomize data)");
         ot_aes_randomize(s, r->iv, ARRAY_SIZE(r->iv));
+    } else {
+        trace_ot_aes_init("iv init (data preserved)");
     }
     bitmap_zero(r->iv_bm, PARAM_NUM_REGS_IV);
     c->iv_ready = false;
@@ -873,13 +878,18 @@ static void ot_aes_process(OtAESState *s)
     c->di_full = false;
 
     if (rc == CRYPT_OK) {
-        /* IV registers are updated on each round */
+        /*
+         * IV registers are updated on each round. For details, see:
+         * https://opentitan.org/book/hw/ip/aes/doc/theory_of_operation.html
+         * https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation
+         */
         switch (mode) {
         case AES_CBC:
             memcpy(c->iv, c->cbc.IV, sizeof(c->iv));
             break;
         case AES_CFB:
-            memcpy(c->iv, c->cfb.IV, sizeof(c->iv));
+            /* In CFB mode the next IV register value is the ciphertext */
+            memcpy(c->iv, encrypt ? c->dst : c->src, sizeof(c->iv));
             break;
         case AES_OFB:
             memcpy(c->iv, c->ofb.IV, sizeof(c->iv));


### PR DESCRIPTION
In AES CFB mode after a block operation the IV registers are updated with the ciphertext from the previous block operation. See:

- https://opentitan.org/book/hw/ip/aes/doc/theory_of_operation.html#datapath-architecture-and-operation
- https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)

LibTomCrypt does not provide this, so we just read it directly from our own data. Previously, we were using the updated IV value that LibTomCrypt provides, which is instead updated to be the output of the block operation (without the XOR with the plaintext).

This fix allows the aes_functest to pass.