### PR TITLE
Fix single-letter typo and add missing flag in index.md

### DIFF
--- a/docs/opentitan/index.md
+++ b/docs/opentitan/index.md
@@ -18,7 +18,7 @@ ninja
 ninja qemu-img
 ````
 
-* `--enable-gtk` and `--enable-cococa` are only useful when using a graphical display, such as the
+* `--enable-gtk` and `--enable-cocoa` are only useful when using a graphical display, such as the
   IbexDemo platform. It is mosly useless with the OpenTitan platform.
 
     * `--enable-gtk` should be used on Linux hosts

--- a/docs/opentitan/index.md
+++ b/docs/opentitan/index.md
@@ -13,15 +13,16 @@ Note: never tested on Windows hosts.
 mkdir build
 cd build
 ../configure --target-list=riscv32-softmmu --without-default-features --enable-tcg \
-    --enable-tools --enable-trace-backends=log [--enable-gtk | --enable-cocoa]
+    --enable-tools --enable-trace-backends=log \
+    [--enable-gtk --enable-pixman | --enable-cocoa]
 ninja
 ninja qemu-img
 ````
 
-* `--enable-gtk` and `--enable-cocoa` are only useful when using a graphical display, such as the
-  IbexDemo platform. It is mosly useless with the OpenTitan platform.
+* `--enable-gtk --enable-pixman` and `--enable-cocoa` are only useful when using a graphical
+  display, such as the IbexDemo platform. It is mosly useless with the OpenTitan platform.
 
-    * `--enable-gtk` should be used on Linux hosts
+    * `--enable-gtk --enable-pixman` should be used on Linux hosts
     * `--enable-cocoa` should be used on macOS hosts
 
 * `--extra-cflags=-Wno-deprecated-declarations` and


### PR DESCRIPTION
This PR fixes the typo --enable-cococa -> --enable-cocoa in index.md and adds the now-required --enable-pixman flag in the case where --enable-gtk is used.

From initial PR: #75