### PR TITLE
[ot] Define (unused) OTP scrambling properties for EG

### DIFF
--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -490,6 +490,15 @@ struct OtOTPEgState {
     OtOtpBeIf *otp_backend;
     OtEDNState *edn;
     uint8_t edn_ep;
+    /*
+     * OTP scrambling property strings (currently unused).
+     * See issue https://github.com/lowRISC/qemu/issues/121.
+     */
+    char *scrmbl_key_xstr;
+    char *digest_const_xstr;
+    char *digest_iv_xstr;
+    char *sram_const_xstr;
+    char *sram_iv_xstr;
 };
 /* clang-format on */
 
@@ -1214,6 +1223,15 @@ static Property ot_otp_eg_properties[] = {
                      OtOtpBeIf *),
     DEFINE_PROP_LINK("edn", OtOTPEgState, edn, TYPE_OT_EDN, OtEDNState *),
     DEFINE_PROP_UINT8("edn-ep", OtOTPEgState, edn_ep, UINT8_MAX),
+    /*
+     * OTP scrambling property strings (currently unused).
+     * See issue https://github.com/lowRISC/qemu/issues/121.
+     */
+    DEFINE_PROP_STRING("scrmbl_key", OtOTPEgState, scrmbl_key_xstr),
+    DEFINE_PROP_STRING("digest_const", OtOTPEgState, digest_const_xstr),
+    DEFINE_PROP_STRING("digest_iv", OtOTPEgState, digest_iv_xstr),
+    DEFINE_PROP_STRING("sram_const", OtOTPEgState, sram_const_xstr),
+    DEFINE_PROP_STRING("sram_iv", OtOTPEgState, sram_iv_xstr),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1104,18 +1104,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("backend", OTP_BACKEND)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_UINT_PROP("edn-ep", 1u),
-            IBEX_DEV_STRING_PROP("scrmbl_key",
-                "cebeb96ffe0eced795f8b2cfe23c1e51"
-                "9e4fa08047a6bcfb811b04f0a479006e"),
-            IBEX_DEV_STRING_PROP("digest_const",
-                "e048b657396b4b83277195fc471e4b26"),
-            IBEX_DEV_STRING_PROP("digest_iv",
-                "4d5a89aa9109294a"),
-            IBEX_DEV_STRING_PROP("sram_const",
-                "63b9485a3856c417cf7a50a9a91ef7f7"),
-            IBEX_DEV_STRING_PROP("sram_iv",
-                "bee3958332f2939b")
+            IBEX_DEV_UINT_PROP("edn-ep", 1u)
         ),
     },
     [OT_DJ_SOC_DEV_OTP_BACKEND] = {

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -567,20 +567,6 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
         ),
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_UINT_PROP("edn-ep", 1u)
-            // Scrambling support is yet to be backported from Darjeeling
-            // implementation. Those are the Earlgrey constants defined for
-            // Earlgrey-M2.5.2-RC0:
-            // IBEX_DEV_STRING_PROP("scrmbl_key",
-            //     "605fefe9977b00b6fdc21d577a172d04"
-            //     "7dcf0eebbdd268afd4e2506df1d0603f"),
-            // IBEX_DEV_STRING_PROP("digest_const",
-            //     "30faa0c47e3809585a24109fbc53e920"),
-            // IBEX_DEV_STRING_PROP("digest_iv",
-            //     "af12b341a53780ab"),
-            // IBEX_DEV_STRING_PROP("sram_const",
-            //     "5f2c075769000c39cda36eab93cd263d"),
-            // IBEX_DEV_STRING_PROP("sram_iv",
-            //     "f2dae31d857d1d39")
         ),
     },
     [OT_EG_SOC_DEV_OTP_BACKEND] = {


### PR DESCRIPTION
Earl Grey does not support OTP scrambling and does not have these parameters declared. QEMU complains when they are provided by the INI file generated by `cfggen.py.

This PR declares the properties but does not use them to silence this warning. It also removes the default values set in `ot_{darjeeling,earlgrey}` to avoid silent misconfigurations if these change.

I did not notice that this was an issue before because I've been erroneously using `-T earlgrey` and not `EarlGrey` so the table was called `ot-otp-e` and wasn't being used.