### PR TITLE
[ot] scripts/opentitan: cfggen.py: fix regression introduced with bc4626ec

### DIFF
--- a/scripts/opentitan/cfggen.py
+++ b/scripts/opentitan/cfggen.py
@@ -64,7 +64,7 @@ class OtConfiguration:
         """Load data from HJSON top configuration file."""
         assert not _HJSON_ERROR
         with open(toppath, 'rt') as tfp:
-            cfg = hjload(tfp)
+            cfg = hjload(tfp, object_pairs_hook=dict)
         self._top_name = cfg.get('name')
         for module in cfg.get('module') or []:
             modtype = module.get('type')
@@ -334,7 +334,6 @@ def main():
         if not isfile(lcpath):
             argparser.error(f"No such file '{ocpath}'")
 
-        cfg = OtConfiguration()
         cfg.load_lifecycle(lcpath)
         cfg.load_otp_constants(ocpath)
         cfg.save(topvar, args.socid, args.count, args.out)


### PR DESCRIPTION
- `ot-rom_ctrl` table and `ot-otp-eg.scrmbl_key` had been removed.

`OtpConfiguration` was instantiated twice.

Also use a regular ordered dict (py3.7+) rather than a legacy OrderedDict for managing HJSON content.