### PR TITLE
Use Python 3.9 syntax for type unions

### DIFF
--- a/python/qemu/ot/dm/dm.py
+++ b/python/qemu/ot/dm/dm.py
@@ -10,7 +10,7 @@ from enum import IntEnum
 from io import SEEK_END
 from logging import getLogger
 from time import sleep, time as now
-from typing import Any, BinaryIO, Optional
+from typing import Any, BinaryIO, Optional, Union
 
 from .regs import CSRS, GPRS
 from ..bitfield import BitField
@@ -277,7 +277,7 @@ class DebugModule:
             self._log.error('Status %s', status)
             raise TimeoutError(f'Cannot resume hart {self._hart}')
 
-    def read_csr(self, reg: [str | int]) -> int:
+    def read_csr(self, reg: Union[str, int]) -> int:
         """Read the value of a CSR."""
         ireg = self._get_register_index(reg)
         btf = self.BITFIELDS['COMMAND']
@@ -292,7 +292,7 @@ class DebugModule:
         self._log.info('read %s = %08x', reg, value)
         return value
 
-    def write_csr(self, reg: [str | int], value: int) -> None:
+    def write_csr(self, reg: Union[str, int], value: int) -> None:
         """Write a value to a CSR."""
         ireg = self._get_register_index(reg)
         btf = self.BITFIELDS['COMMAND']
@@ -497,7 +497,7 @@ class DebugModule:
         self._log.debug('read 0x%08x', value)
         return value
 
-    def _get_register_index(self, reg: [str | int]) -> int:
+    def _get_register_index(self, reg: Union[str, int]) -> int:
         if isinstance(reg, str):
             # Not supported: FPR, Vector, etc.
             ireg = CSRS.get(reg.lower())

--- a/python/qemu/ot/dm/otp.py
+++ b/python/qemu/ot/dm/otp.py
@@ -10,7 +10,7 @@ from binascii import unhexlify
 from enum import IntEnum
 from logging import getLogger
 from time import sleep, time as now
-from typing import Optional
+from typing import Optional, Union
 
 from .dm import DebugModule
 from ..bitfield import BitField
@@ -166,7 +166,7 @@ class OTPController:
         return partition.secret or (partition.digest_offset == offset & ~0b111)
 
     def read_partition_item(self, partname: str, itemname: str) \
-            -> [int | bytes]:
+            -> Union[int, bytes]:
         pname = partname.upper()
         try:
             part = self._partitions[pname]
@@ -205,7 +205,7 @@ class OTPController:
         return bytes(buffer)
 
     def write_partition_item(self, partname: str, itemname: str,
-                             value: [int | bytes | bytearray | str]) -> None:
+                             value: Union[int, bytes, bytearray, str]) -> None:
         pname = partname.upper()
         try:
             part = self._partitions[pname]

--- a/python/qemu/ot/lc_ctrl/lcdmi.py
+++ b/python/qemu/ot/lc_ctrl/lcdmi.py
@@ -9,7 +9,7 @@
 from binascii import Error as BinasciiError, hexlify, unhexlify
 from logging import getLogger
 from struct import pack as spack, unpack as sunpack
-from typing import NamedTuple
+from typing import NamedTuple, Union
 
 from . import LifeCycleError
 from ..dtm import DebugTransportModule
@@ -183,7 +183,7 @@ class LifeCycleController:
         return token
 
     @transition_token.setter
-    def transition_token(self, token: [bytes | bytearray | str | None]) -> None:
+    def transition_token(self, token: Union[bytes, bytearray, str, None]) -> None:
         """Define the transition token as a 16-byte token.
 
            :param token: if None, use an empty zeroed token,
@@ -216,7 +216,7 @@ class LifeCycleController:
         return starget, target
 
     @transition_target.setter
-    def transition_target(self, target: [str | int]) -> None:
+    def transition_target(self, target: Union[str, int]) -> None:
         """Define the transition token as a 16-byte token."""
         if isinstance(target, str):
             itarget = self._encode_state(target)
@@ -240,7 +240,7 @@ class LifeCycleController:
         return self._read_reg('otp_vendor_test_status')
 
     @property
-    def lc_state(self) -> [str | int]:
+    def lc_state(self) -> Union[str, int]:
         """Report the current state."""
         istate = self._read_reg('lc_state')
         tix = self._check_state(istate)

--- a/python/qemu/ot/otp/partition.py
+++ b/python/qemu/ot/otp/partition.py
@@ -9,7 +9,7 @@
 from binascii import hexlify, unhexlify, Error as hexerror
 from io import BytesIO
 from logging import getLogger
-from typing import BinaryIO, Optional, TextIO
+from typing import BinaryIO, Optional, TextIO, Union
 
 from .lifecycle import OtpLifecycle
 
@@ -23,7 +23,7 @@ except ImportError:
 class OtpPartitionDecoder:
     """Custom partition value decoder."""
 
-    def decode(self, category: str, seq: str) -> Optional[str | int]:
+    def decode(self, category: str, seq: str) -> Optional[Union[str, int]]:
         """Decode a value (if possible)."""
         raise NotImplementedError('abstract base class')
 
@@ -206,7 +206,7 @@ class OtpLifecycleExtension(OtpLifecycle, OtpPartitionDecoder):
     """Decoder for Lifecyle bytes sequences.
     """
 
-    def decode(self, category: str, seq: str) -> Optional[str | int]:
+    def decode(self, category: str, seq: str) -> Optional[Union[str, int]]:
         try:
             iseq = hexlify(bytes(reversed(unhexlify(seq)))).decode()
         except (ValueError, TypeError, hexerror) as exc:

--- a/python/qemu/ot/spi/spi_device.py
+++ b/python/qemu/ot/spi/spi_device.py
@@ -13,7 +13,7 @@ from socket import (create_connection, socket, IPPROTO_TCP, TCP_NODELAY,
                     SHUT_RDWR, timeout as LegacyTimeoutError)
 from struct import calcsize as scalc, pack as spack
 from time import sleep, time as now
-from typing import Optional
+from typing import Optional, Union
 
 
 class SpiDevice:
@@ -102,7 +102,7 @@ class SpiDevice:
             self._socket = None
 
     def transmit(self, cmd: Optional[int] = None,
-                 in_payload: Optional[bytes | bytearray | int] = None,
+                 in_payload: Optional[Union[bytes, bytearray, int]] = None,
                  out_len: int = 0, release: bool = True) -> bytes:
         """SPI data transfer.
 

--- a/python/qemu/ot/util/log.py
+++ b/python/qemu/ot/util/log.py
@@ -156,7 +156,7 @@ class ColorLogFormatter(logging.Formatter):
         formatter = logging.Formatter(log_fmt, *self._formatter_args)
         return formatter.format(record)
 
-    def add_logger_colors(self, logname: str, color: Union[int | str]) -> None:
+    def add_logger_colors(self, logname: str, color: Union[int, str]) -> None:
         """Assign a color to the message of a specific logger."""
         if not self._use_ansi:
             return
@@ -190,7 +190,7 @@ class ColorLogFormatter(logging.Formatter):
         cls.XCOLORS = xcolors
 
 
-def configure_loggers(level: int, *lognames: list[Union[str | int | Color]],
+def configure_loggers(level: int, *lognames: list[Union[str, int, Color]],
                       **kwargs) -> list[logging.Logger]:
     """Configure loggers.
 

--- a/python/qemu/ot/util/misc.py
+++ b/python/qemu/ot/util/misc.py
@@ -8,14 +8,14 @@
 
 from io import BytesIO
 from sys import stdout
-from typing import Any, Iterable, Optional, TextIO
+from typing import Any, Iterable, Optional, TextIO, Union
 import re
 
 try:
     # only available from Python 3.12+
     from collections.abc import Buffer
 except ImportError:
-    Buffer = [bytes | bytearray | memoryview]
+    Buffer = Union[bytes, bytearray, memoryview]
 
 
 class classproperty(property):

--- a/scripts/opentitan/flashgen.py
+++ b/scripts/opentitan/flashgen.py
@@ -18,7 +18,7 @@ from os.path import (abspath, basename, dirname, exists, isfile,
                      join as joinpath, normpath)
 from struct import calcsize as scalc, pack as spack, unpack as sunpack
 from traceback import format_exc
-from typing import Any, BinaryIO, NamedTuple, Optional
+from typing import Any, BinaryIO, NamedTuple, Optional, Union
 import re
 import sys
 
@@ -216,7 +216,7 @@ class FlashGen:
         return sum(cls.INFOS) * cls.BYTES_PER_PAGE
 
     def read_boot_info(self) -> dict[BootLocation,
-                                     dict[str, [int | bytes]]]:
+                                     dict[str, Union[int, bytes]]]:
         size = self._boot_header_size
         fmt = ''.join(self.BOOT_HEADER_FORMAT.values())
         boot_entries = {}

--- a/scripts/opentitan/gdbreplay.py
+++ b/scripts/opentitan/gdbreplay.py
@@ -17,7 +17,7 @@ from socket import (SOL_SOCKET, SO_REUSEADDR, SHUT_RDWR, socket,
                     timeout as LegacyTimeoutError)
 from string import ascii_uppercase
 from traceback import format_exc
-from typing import BinaryIO, Optional, TextIO
+from typing import BinaryIO, Optional, TextIO, Union
 import re
 import sys
 
@@ -461,7 +461,7 @@ class QEMUGDBReplay:
         self._log.info('Reply: "%s"', payload)
         self._send_bytes(payload.encode())
 
-    def _send_bytes(self, payload: [bytes | bytearray]):
+    def _send_bytes(self, payload: Union[bytes, bytearray]):
         """Send a reply to the remote GDB client.
 
            :param payload: the byte sequence to send


### PR DESCRIPTION
The `|` syntax was added in 3.10 (I think).

With this change I was able to run `cfggen.py` and `pyot.py` with Python 3.9.

I didn't add a component to the commit messages, so CI will complain.