### PR TITLE
[ot] hw/opentitan: ot_clkmgr, ot_spi_host: Earlgrey 1.0.0 backwards compatability

### DIFF
--- a/hw/opentitan/ot_clkmgr.c
+++ b/hw/opentitan/ot_clkmgr.c
@@ -45,6 +45,9 @@
 #define PARAM_NUM_HINTABLE_CLOCKS    4u
 #define PARAM_NUM_ALERTS             2u
 
+/* undef to build for `master`, not for Earlgrey 1.0 */
+#define OT_IS_EARLGREY_V1_0_0
+
 /* clang-format off */
 REG32(ALERT_TEST, 0x0u)
     FIELD(ALERT_TEST, RECOV_FAULT, 0u, 1u)
@@ -341,13 +344,22 @@ static void ot_clkmgr_write(void *opaque, hwaddr addr, uint64_t val64,
         s->regs[reg] &= val32;
         break;
     case R_JITTER_ENABLE:
-        if (s->regs[R_JITTER_REGWEN]) {
+#ifdef OT_IS_EARLGREY_V1_0_0
+	/*
+	 * There is a known bug in Earlgrey 1.0.0, where the Clkmgr Jitter Enable
+	 * REGWEN was not properly connected, meaning it is unused here.
+	 */
+	val32 &= R_JITTER_ENABLE_VAL_MASK;
+	s->regs[reg] = val32;
+#else
+	if (s->regs[R_JITTER_REGWEN]) {
             val32 &= R_JITTER_ENABLE_VAL_MASK;
             s->regs[reg] = val32;
         } else {
             qemu_log_mask(LOG_GUEST_ERROR,
                           "%s: JITTER_ENABLE protected w/ REGWEN\n", __func__);
         }
+#endif
         break;
     case R_CLK_ENABLES:
         val32 &= CLK_ENABLES_MASK;

--- a/hw/opentitan/ot_spi_host.c
+++ b/hw/opentitan/ot_spi_host.c
@@ -66,6 +66,9 @@
 #define RXFIFO_LEN  256U /* bytes */
 #define CMDFIFO_LEN 4U /* slots */
 
+/* undef to build for `master`, not for Earlgrey 1.0 */
+#define OT_IS_EARLGREY_V1_0_0
+
 /* ------------------------------------------------------------------------ */
 /* Register definitions */
 /* ------------------------------------------------------------------------ */
@@ -110,10 +113,17 @@ REG32(CONFIGOPTS, 0x18u)
 REG32(CSID, 0x1cu)
     FIELD(CSID, CSID, 0u, 32u)
 REG32(COMMAND, 0x20u)
+#ifdef OT_IS_EARLGREY_V1_0_0
+    FIELD(COMMAND, LEN, 0u, 9u)
+    FIELD(COMMAND, CSAAT, 9u, 1u)
+    FIELD(COMMAND, SPEED, 10u, 2u)
+    FIELD(COMMAND, DIRECTION, 12u, 2u)
+#else
     FIELD(COMMAND, CSAAT, 0u, 1u)
     FIELD(COMMAND, SPEED, 1u, 2u)
     FIELD(COMMAND, DIRECTION, 3u, 2u)
     FIELD(COMMAND, LEN, 5u, 20u)
+#endif
 REG32(RXDATA, 0x24u)
 REG32(TXDATA, 0x28u)
 REG32(ERROR_ENABLE, 0x2cu)


### PR DESCRIPTION
This PR is to a new branch intended to maintain temporary backwards compatibility with the `earlgrey-1.0.0` target. This includes reverting HW changes to the QEMU model since that branch was taken (including the SPI Host changes), and replicating RTL bugs present in that version (e.g. the clkmgr bug in this PR).

This branch is intended to likely be a temporary workaround: it would be nice to have a better solution for supporting different tops in QEMU, where `earlgrey-1.0.0` could just be a slightly modified top from Earlgrey master, but since we have need for this now we just manually ad this with some conditional `#ifdef`s.