### PR TITLE
Fix regressions in Earlgrey 1.0.0 tests

### DIFF
--- a/hw/opentitan/ot_clkmgr.c
+++ b/hw/opentitan/ot_clkmgr.c
@@ -267,6 +267,22 @@ struct OtClkMgrState {
     char *cfg_hint;
 };
 
+/*
+ * Device state-index pair used as opaque data with the `ot_clkmgr_clock_hint`
+ * clock hint callback.
+ *
+ * To enable dynamic clock-hinting across IP based on the clocks defined in the
+ * property strings, we need to expose the clock hint signal as a named GPIO
+ * input to the QDev, but by creating individual named signals instead of an
+ * array we lose the context of the hint number.
+ *
+ * We hence must pass additional opaque data to describe the hint index.
+ */
+typedef struct {
+    OtClkMgrState *state;
+    unsigned hint_index;
+} OtClkMgrHintContext;
+
 struct OtClkMgrClass {
     SysBusDeviceClass parent_class;
     ResettablePhases parent_phases;
@@ -341,10 +357,11 @@ static void ot_clkmgr_update_swcg(OtClkMgrState *s, uint32_t change)
 
 static void ot_clkmgr_clock_hint(void *opaque, int irq, int level)
 {
-    OtClkMgrState *s = opaque;
+    OtClkMgrHintContext *hint_ctx = opaque;
+    OtClkMgrState *s = hint_ctx->state;
+    unsigned hint = hint_ctx->hint_index;
 
-    unsigned hint = (unsigned)irq;
-
+    g_assert(irq == 0);
     g_assert(hint < s->hint_count);
 
     trace_ot_clkmgr_clock_hint(s->ot_id, s->hints[hint]->name, hint,
@@ -811,10 +828,15 @@ static void ot_clkmgr_configure_groups(gpointer data, gpointer user_data)
         for (GList *cnode = group->clocks; cnode; cnode = cnode->next) {
             OtClkMgrClock *clk = (OtClkMgrClock *)(cnode->data);
 
+            OtClkMgrHintContext *hint_ctx = g_new0(OtClkMgrHintContext, 1u);
+            hint_ctx->state = s;
+            hint_ctx->hint_index = s->hint_count;
+
             char *hintname = g_strdup_printf(OT_CLOCK_HINT_PREFIX "%s.%s",
                                              group->name, clk->name);
-            qdev_init_gpio_in_named(DEVICE(s), &ot_clkmgr_clock_hint, hintname,
-                                    1);
+            qdev_init_gpio_in_named_with_opaque(DEVICE(s),
+                                                &ot_clkmgr_clock_hint, hint_ctx,
+                                                hintname, 1);
             trace_ot_clkmgr_create(s->ot_id, "hint", hintname);
             g_free(hintname);
 

--- a/hw/opentitan/ot_clkmgr.c
+++ b/hw/opentitan/ot_clkmgr.c
@@ -2,6 +2,7 @@
  * QEMU OpenTitan Clock manager device
  *
  * Copyright (c) 2023-2025 Rivos, Inc.
+ * Copyright (c) 2025 lowRISC contributors.
  *
  * Author(s):
  *  Emmanuel Blot <eblot@rivosinc.com>
@@ -983,6 +984,8 @@ static uint64_t ot_clkmgr_read(void *opaque, hwaddr addr, unsigned size)
     case R_CLK_ENABLES:
     case R_CLK_HINTS:
     case R_MEASURE_CTRL_REGWEN:
+        val32 = s->regs[reg];
+        break;
     case R_CLK_HINTS_STATUS:
         val32 = ot_clkmgr_get_clock_hints(s);
         break;

--- a/hw/opentitan/ot_lc_ctrl.c
+++ b/hw/opentitan/ot_lc_ctrl.c
@@ -2,6 +2,7 @@
  * QEMU OpenTitan Life Cycle controller device
  *
  * Copyright (c) 2023-2025 Rivos, Inc.
+ * Copyright (c) 2025 lowRISC contributors.
  *
  * Author(s):
  *  Emmanuel Blot <eblot@rivosinc.com>
@@ -324,8 +325,10 @@ typedef enum {
 /* Life cycle state group diversification value for keymgr */
 typedef enum {
     LC_DIV_INVALID,
-    LC_DIV_TEST_DEV_RMA,
+    LC_DIV_TEST_UNLOCKED,
+    LC_DIV_DEV,
     LC_DIV_PROD,
+    LC_DIV_RMA,
     LC_DIV_COUNT,
 } OtLcCtrlKeyMgrDivType;
 
@@ -770,13 +773,13 @@ static void ot_lc_ctrl_update_broadcast(OtLcCtrlState *s)
             sigbm = LC_BCAST_BIT(RAW_TEST_RMA) | LC_BCAST_BIT(DFT_EN) |
                     LC_BCAST_BIT(NVM_DEBUG_EN) | LC_BCAST_BIT(HW_DEBUG_EN) |
                     LC_BCAST_BIT(CPU_EN) | LC_BCAST_BIT(ISO_PART_SW_WR_EN);
-            div_type = LC_DIV_TEST_DEV_RMA;
+            div_type = LC_DIV_TEST_UNLOCKED;
             break;
         case LC_STATE_TESTUNLOCKED7:
             sigbm = LC_BCAST_BIT(RAW_TEST_RMA) | LC_BCAST_BIT(DFT_EN) |
                     LC_BCAST_BIT(HW_DEBUG_EN) | LC_BCAST_BIT(CPU_EN) |
                     LC_BCAST_BIT(ISO_PART_SW_WR_EN);
-            div_type = LC_DIV_TEST_DEV_RMA;
+            div_type = LC_DIV_TEST_UNLOCKED;
             break;
         case LC_STATE_PROD:
         case LC_STATE_PRODEND:
@@ -810,7 +813,7 @@ static void ot_lc_ctrl_update_broadcast(OtLcCtrlState *s)
             if (s->regs[R_LC_ID_STATE] == LC_ID_STATE_PERSONALIZED) {
                 sigbm |= LC_BCAST_BIT(SEED_HW_RD_EN);
             }
-            div_type = LC_DIV_TEST_DEV_RMA;
+            div_type = LC_DIV_DEV;
             break;
         case LC_STATE_RMA:
             sigbm =
@@ -822,7 +825,7 @@ static void ot_lc_ctrl_update_broadcast(OtLcCtrlState *s)
                 LC_BCAST_BIT(OWNER_SEED_SW_RW_EN) |
                 LC_BCAST_BIT(ISO_PART_SW_RD_EN) |
                 LC_BCAST_BIT(ISO_PART_SW_WR_EN) | LC_BCAST_BIT(SEED_HW_RD_EN);
-            div_type = LC_DIV_TEST_DEV_RMA;
+            div_type = LC_DIV_RMA;
             break;
         case LC_STATE_SCRAP:
         default:
@@ -2129,9 +2132,11 @@ static Property ot_lc_ctrl_properties[] = {
     DEFINE_PROP_STRING("raw_unlock_token", OtLcCtrlState,
                        raw_unlock_token_xstr),
     DEFINE_PROP_STRING("invalid", OtLcCtrlState, km_div_xstrs[LC_DIV_INVALID]),
+    DEFINE_PROP_STRING("test_unlocked", OtLcCtrlState,
+                       km_div_xstrs[LC_DIV_TEST_UNLOCKED]),
+    DEFINE_PROP_STRING("dev", OtLcCtrlState, km_div_xstrs[LC_DIV_DEV]),
     DEFINE_PROP_STRING("production", OtLcCtrlState, km_div_xstrs[LC_DIV_PROD]),
-    DEFINE_PROP_STRING("test_dev_rma", OtLcCtrlState,
-                       km_div_xstrs[LC_DIV_TEST_DEV_RMA]),
+    DEFINE_PROP_STRING("rma", OtLcCtrlState, km_div_xstrs[LC_DIV_RMA]),
     DEFINE_PROP_STRING("lc_state_first", OtLcCtrlState,
                        trans_cfg[LC_CTRL_TRANS_LC_STATE]
                            .state[LC_CTRL_TSTATE_FIRST]),

--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -2,6 +2,7 @@
  * QEMU OpenTitan EarlGrey One Time Programmable (OTP) memory controller
  *
  * Copyright (c) 2023-2025 Rivos, Inc.
+ * Copyright (c) 2025 lowRISC contributors.
  *
  * Author(s):
  *  Emmanuel Blot <eblot@rivosinc.com>
@@ -452,6 +453,10 @@ typedef struct {
     uint16_t iskeymgr : 1;
 } OtOTPPartDesc;
 
+#define OT_OTP_EG_PARTS
+/* NOLINTNEXTLINE */
+#include "ot_otp_eg_parts.c"
+
 typedef struct {
     uint32_t *storage; /* overall buffer for the storage backend */
     uint32_t *data; /* data buffer (all partitions) */
@@ -501,6 +506,7 @@ struct OtOTPEgState {
     char *digest_iv_xstr;
     char *sram_const_xstr;
     char *sram_iv_xstr;
+    char *inv_default_part_xstrs[ARRAY_SIZE(OtOTPPartDescs)]; /* may be NULL */
 };
 /* clang-format on */
 
@@ -508,10 +514,6 @@ struct OtOTPEgState {
 
 /* initialized to zero, i.e. no valid token declared for now */
 static const OtOTPTokens OT_OTP_EG_TOKENS;
-
-#define OT_OTP_EG_PARTS
-/* NOLINTNEXTLINE */
-#include "ot_otp_eg_parts.c"
 
 #define LC_TRANSITION_COUNT_MAX 24u
 #define LC_STATE_BIT_WIDTH      5u
@@ -1226,6 +1228,26 @@ ot_otp_eg_ctrl_get_entropy_cfg(const OtOTPState *s)
     return ds->entropy_cfg;
 }
 
+static void ot_otp_eg_class_add_inv_def_props(OtOTPClass *odc)
+{
+    for (unsigned ix = 0; ix < ARRAY_SIZE(OtOTPPartDescs); ix++) {
+        if (!OtOTPPartDescs[ix].buffered) {
+            continue;
+        }
+
+        Property *prop = g_new0(Property, 1u);
+
+        prop->name = g_strdup_printf("inv_default_part_%u", ix);
+        prop->info = &qdev_prop_string;
+        prop->offset = offsetof(OtOTPEgState, inv_default_part_xstrs) +
+                       sizeof(char *) * ix;
+
+        object_class_property_add(OBJECT_CLASS(odc), prop->name,
+                                  prop->info->name, prop->info->get,
+                                  prop->info->set, prop->info->release, prop);
+    }
+}
+
 static Property ot_otp_eg_properties[] = {
     DEFINE_PROP_STRING(OT_COMMON_DEV_ID, OtOTPEgState, ot_id),
     DEFINE_PROP_DRIVE("drive", OtOTPEgState, blk),
@@ -1453,6 +1475,8 @@ static void ot_otp_eg_class_init(ObjectClass *klass, void *data)
     oc->get_lc_info = &ot_otp_eg_ctrl_get_lc_info;
     oc->get_hw_cfg = &ot_otp_eg_ctrl_get_hw_cfg;
     oc->get_entropy_cfg = &ot_otp_eg_ctrl_get_entropy_cfg;
+
+    ot_otp_eg_class_add_inv_def_props(oc);
 }
 
 static const TypeInfo ot_otp_eg_info = {

--- a/hw/opentitan/ot_rstmgr.c
+++ b/hw/opentitan/ot_rstmgr.c
@@ -2,6 +2,7 @@
  * QEMU OpenTitan Reset Manager device
  *
  * Copyright (c) 2023-2025 Rivos, Inc.
+ * Copyright (c) 2025 lowRISC contributors.
  *
  * Author(s):
  *  Emmanuel Blot <eblot@rivosinc.com>
@@ -609,7 +610,15 @@ static void ot_rstmgr_reset_enter(Object *obj, ResetType type)
 
     for (unsigned devix = 0; devix < OT_RSTMGR_SW_RESET_MAX; devix++) {
         const OtRstMgrResettable *rst = &config->sw_resettable_devices[devix];
-        if (rst->typename) {
+        /*
+         * On Earlgrey, not all SW resettable devices are implemented yet, but
+         * there is still merit in resetting these registers so that they can
+         * be tested as part of the rstmgr implementation.
+         *
+         * TODO: remove this version check when USBDEV and I2C are implemented
+         * and connected to the `rstmgr`.
+         */
+        if (rst->typename || s->version == OT_RSTMGR_VERSION_EG_252) {
             s->regs[R_SW_RST_REGWEN_0 + devix] = SW_RST_REGWEN_EN_MASK;
             s->regs[R_SW_RST_CTRL_N_0 + devix] = SW_RST_CTRL_VAL_MASK;
         }

--- a/hw/opentitan/ot_rstmgr.c
+++ b/hw/opentitan/ot_rstmgr.c
@@ -189,6 +189,7 @@ typedef struct {
 typedef struct {
     char *path;
     bool reset;
+    char *ot_id;
 } OtRstMgrResetDesc;
 
 typedef struct {
@@ -300,7 +301,6 @@ static void ot_rstmgr_reset_bus(void *opaque)
 
 static int ot_rstmgr_sw_rst_walker(DeviceState *dev, void *opaque)
 {
-    OtRstMgrState *s = OT_RSTMGR(dev);
     OtRstMgrResetDesc *desc = opaque;
 
     int match =
@@ -311,7 +311,7 @@ static int ot_rstmgr_sw_rst_walker(DeviceState *dev, void *opaque)
         return 0;
     }
 
-    trace_ot_rstmgr_sw_rst(s->ot_id, desc->path, desc->reset);
+    trace_ot_rstmgr_sw_rst(desc->ot_id, desc->path, desc->reset);
 
     if (desc->reset) {
         resettable_assert_reset(OBJECT(dev), RESET_TYPE_COLD);
@@ -341,6 +341,7 @@ static void ot_rstmgr_update_sw_reset(OtRstMgrState *s, unsigned devix)
 
     desc.path = g_strdup_printf("%s[%d]", rst->typename, rst->idx);
     desc.reset = !s->regs[R_SW_RST_CTRL_N_0 + devix];
+    desc.ot_id = s->ot_id;
 
     trace_ot_rstmgr_sw_reset(s->ot_id, desc.path);
 

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -999,9 +999,9 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
             { .base = 0x41110000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_EG_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 165),
-            OT_EG_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 166),
-            OT_EG_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 167),
+            OT_EG_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 166),
+            OT_EG_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 167),
+            OT_EG_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 168),
             OT_EG_SOC_GPIO_ALERT(0, 44)
         ),
         .link = IBEXDEVICELINKDEFS(
@@ -1039,7 +1039,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
             { .base = 0x41130000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_EG_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 171),
+            OT_EG_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 172),
             OT_EG_SOC_GPIO_ALERT(0, 47),
             OT_EG_SOC_GPIO_ALERT(1, 48)
         ),

--- a/scripts/opentitan/cfggen.py
+++ b/scripts/opentitan/cfggen.py
@@ -500,7 +500,7 @@ def main():
         log = configure_loggers(args.verbose, 'cfggen', 'otp')[0]
 
         if _HJSON_ERROR:
-            argparser.error('Missing HJSON module: {_HJSON_ERROR}')
+            argparser.error(f'Missing HJSON module: {_HJSON_ERROR}')
 
         cfg = OtConfiguration()
 

--- a/scripts/opentitan/cfggen.py
+++ b/scripts/opentitan/cfggen.py
@@ -561,11 +561,20 @@ def main():
             argparser.error(f"No such file '{lcpath}'")
 
         if not args.otpconst:
-            ocpath = joinpath(ot_dir, 'hw', top,
-                              'ip_autogen/otp_ctrl/rtl/otp_ctrl_part_pkg.sv')
+            otp_constant_locations = [
+                joinpath(
+                    ot_dir, "hw", top, "ip_autogen/otp_ctrl/rtl/otp_ctrl_part_pkg.sv"
+                ),
+                joinpath(ot_dir, 'hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv'),
+            ]
+            ocpath = None
+            for maybe_ocpath in otp_constant_locations:
+                if isfile(maybe_ocpath):
+                    ocpath = maybe_ocpath
+                    break
         else:
             ocpath = args.otpconst
-        if not isfile(lcpath):
+        if ocpath is None or not isfile(lcpath):
             argparser.error(f"No such file '{ocpath}'")
 
         cfg.load_lifecycle(lcpath)


### PR DESCRIPTION
This PR introduces commits to allow us to continue building QEMU OpenTitan configurations from the latest OpenTitan `master` / `earlgrey_1.0.0` branches after recent changes. After stubbing out some properties that were expected to be present in the OTP and lc_ctrl, I ran some tests on `earlgrey_1.0.0` to find potential regressions. The last 5 commits contain bug fixes that address any new test failures that were seen. 

See the commit messages for more details.