### PR TITLE
ot_kmac: Add clock hinting

### DIFF
--- a/hw/opentitan/ot_kmac.c
+++ b/hw/opentitan/ot_kmac.c
@@ -444,6 +444,8 @@ ot_kmac_change_fsm_state_line(OtKMACState *s, OtKMACFsmState state, int line)
                                       s->state, STATE_NAME(state), state);
     }
 
+    ibex_irq_set(&s->clock_active, (bool)(state != KMAC_ST_IDLE));
+
     s->state = state;
 }
 

--- a/scripts/opentitan/tests-passing.txt
+++ b/scripts/opentitan/tests-passing.txt
@@ -91,6 +91,7 @@
 //sw/device/tests:hmac_secure_wipe_test_sim_qemu_rom_with_fake_keys
 //sw/device/tests:hmac_smoketest_sim_qemu_rom_with_fake_keys
 //sw/device/tests:kmac_endianess_test_sim_qemu_rom_with_fake_keys
+//sw/device/tests:kmac_idle_test_sim_qemu_rom_with_fake_keys
 //sw/device/tests:kmac_mode_cshake_test_sim_qemu_rom_with_fake_keys
 //sw/device/tests:kmac_mode_kmac_test_sim_qemu_rom_with_fake_keys
 //sw/device/tests:kmac_smoketest_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
Despite the clkmgr connections being present, KMAC hasn't actually had clock hinting implemented, which was causing a failure in the `kmac_idle_test`. Simply implement clock hinting on changes of FSM state.

You can see the relevant RTL [here](https://github.com/lowRISC/opentitan/blob/0fa004ad69a9bda12b3f333689d46970c2c9dc32/hw/ip/kmac/rtl/kmac.sv#L562-L572). It reports idle to the clkmgr as long as the state is idle and the `msg_fifo` is empty - which will always be the case here as we have to be in the `ST_MSG_FEED` FSM state to allow data to be written to the input fifo, and we can only return to `ST_IDLE` by either (a) a HW operation finishing, which doesn't use the input FIFO or (b) SW sends a `DONE` command after processing, where processing will empty the input fifo first.