### PR TITLE
Allow configuring whether `DV_SIM_STATUS` shuts down QEMU

### DIFF
--- a/docs/opentitan/darjeeling.md
+++ b/docs/opentitan/darjeeling.md
@@ -209,6 +209,12 @@ virtual machine. It contains three ASCII chars `QMU` followed with a configurabl
 the MSB, whose meaning is not defined. It can be any 8-byte value, and defaults to 0x0. To configure
 this version field, use the `qemu_version` property of the Ibex Wrapper device.
 
+The `DV_SIM_STATUS` register (address 0 of the `DV_SIM_WINDOW`) can be used to exit QEMU with a
+passing or failing status code. The lower half of the word is written either `900d` (good) or `baad`
+(bad). If an error code is written to the upper half of the word, QEMU will exit with that status
+code for failures. The `-global ot-ibex_wrapper.dv-sim-status-exit=[on|off]` can be used to control
+whether QEMU shuts down when this register is written.
+
 There are two modes to handle address remapping, with different limitations:
 
 - default mode: use an MMU-like implementation (via ot_vmapper) to remap addresses. This mode

--- a/docs/opentitan/earlgrey.md
+++ b/docs/opentitan/earlgrey.md
@@ -181,6 +181,12 @@ virtual machine. It contains three ASCII chars `QMU` followed with a configurabl
 the MSB, whose meaning is not defined. It can be any 8-byte value, and defaults to 0x0. To configure
 this version field, use the `qemu_version` property of the Ibex Wrapper device.
 
+The `DV_SIM_STATUS` register (address 0 of the `DV_SIM_WINDOW`) can be used to exit QEMU with a
+passing or failing status code. The lower half of the word is written either `900d` (good) or `baad`
+(bad). If an error code is written to the upper half of the word, QEMU will exit with that status
+code for failures. The `-global ot-ibex_wrapper.dv-sim-status-exit=[on|off]` can be used to control
+whether QEMU shuts down when this register is written.
+
 There are two modes to handle address remapping, with different limitations:
 
 - default mode: use an MMU-like implementation (via ot_vmapper) to remap addresses. This mode

--- a/hw/opentitan/ot_ibex_wrapper.c
+++ b/hw/opentitan/ot_ibex_wrapper.c
@@ -238,6 +238,7 @@ struct OtIbexWrapperState {
     uint8_t qemu_version;
     bool lc_ignore;
     bool alias_mode;
+    bool dv_sim_status_exit;
     CharBackend chr;
 };
 
@@ -1136,30 +1137,39 @@ static void ot_ibex_wrapper_write_dv_sim_status(OtIbexWrapperState *s,
     (void)reg;
 
     ot_ibex_wrapper_status_report(s, value);
-    switch (value & DV_SIM_STATUS_CODE_MASK) {
-    case TEST_STATUS_PASSED:
-        trace_ot_ibex_wrapper_exit(s->ot_id, "DV SIM success, exiting", 0);
-        qemu_system_shutdown_request_with_code(SHUTDOWN_CAUSE_GUEST_SHUTDOWN,
-                                               0);
-        break;
-    case TEST_STATUS_FAILED: {
-        uint32_t info = SHARED_FIELD_EX32(value, DV_SIM_STATUS_INFO);
-        int ret;
-        if (info == 0) {
-            /* no extra info */
-            ret = 1;
-        } else {
-            ret = (int)(info & 0x7fu);
+
+    if (s->dv_sim_status_exit) {
+        switch (value & DV_SIM_STATUS_CODE_MASK) {
+        case TEST_STATUS_PASSED:
+            trace_ot_ibex_wrapper_exit(s->ot_id, "DV SIM success, exiting", 0);
+            qemu_system_shutdown_request_with_code(
+                SHUTDOWN_CAUSE_GUEST_SHUTDOWN, 0);
+            break;
+        case TEST_STATUS_FAILED: {
+            uint32_t info = SHARED_FIELD_EX32(value, DV_SIM_STATUS_INFO);
+            int ret;
+            if (info == 0) {
+                /* no extra info */
+                ret = 1;
+            } else {
+                ret = (int)(info & 0x7fu);
+            }
+            trace_ot_ibex_wrapper_exit(s->ot_id, "DV SIM failure, exiting",
+                                       ret);
+            qemu_system_shutdown_request_with_code(
+                SHUTDOWN_CAUSE_GUEST_SHUTDOWN, ret);
+            break;
         }
-        trace_ot_ibex_wrapper_exit(s->ot_id, "DV SIM failure, exiting", ret);
-        qemu_system_shutdown_request_with_code(SHUTDOWN_CAUSE_GUEST_SHUTDOWN,
-                                               ret);
-        break;
+        default:
+            break;
+        }
+    } else {
+        trace_ot_ibex_wrapper_exit(s->ot_id,
+                                   "dv-sim-status-exit disabled, not exiting",
+                                   0);
     }
-    default:
-        s->regs.dv_sim_win[DV_SIM_STATUS] = value;
-        break;
-    }
+
+    s->regs.dv_sim_win[DV_SIM_STATUS] = value;
 }
 
 static void ot_ibex_wrapper_write_dv_sim_log(OtIbexWrapperState *s,
@@ -1381,6 +1391,8 @@ static Property ot_ibex_wrapper_properties[] = {
     DEFINE_PROP_UINT8("edn-ep", OtIbexWrapperState, edn_ep, UINT8_MAX),
     DEFINE_PROP_BOOL("lc-ignore", OtIbexWrapperState, lc_ignore, false),
     DEFINE_PROP_BOOL("alias-mode", OtIbexWrapperState, alias_mode, false),
+    DEFINE_PROP_BOOL("dv-sim-status-exit", OtIbexWrapperState,
+                     dv_sim_status_exit, true),
     DEFINE_PROP_UINT8("qemu_version", OtIbexWrapperState, qemu_version, 0),
     DEFINE_PROP_STRING("lc-ignore-ids", OtIbexWrapperState, lc_ignore_ids),
     DEFINE_PROP_CHR("logdev", OtIbexWrapperState, chr),


### PR DESCRIPTION
I'm working on the `opentitantool` integration for QEMU and currently the tool is very reset-happy, for example it needs to reset after bootstrapping. When the test runs after this reset it will write to `DV_SIM_STATUS` and QEMU will shut down before we have a chance to connect to it.

We still want this shutdown  behaviour for manual runs and `pyot.py`, but I'd like to disable it for `opentitantool` so I've made it configurable.