### PR TITLE
Fix CI by adding new i2c_qemu_test

### DIFF
--- a/scripts/opentitan/tests-flaky.txt
+++ b/scripts/opentitan/tests-flaky.txt
@@ -12,5 +12,6 @@
 //sw/device/tests/crypto:aes_gcm_timing_test_sim_qemu_rom_with_fake_keys
 //sw/device/tests/crypto:rsa_2048_keygen_functest_sim_qemu_rom_with_fake_keys
 //sw/device/tests/crypto:rsa_4096_encryption_functest_sim_qemu_rom_with_fake_keys
+//sw/device/tests/qemu:i2c_qemu_test_sim_qemu_rom_with_fake_keys
 //sw/device/tests:edn_auto_mode_sim_qemu_rom_with_fake_keys
 //sw/device/tests:rv_core_ibex_rnd_test_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
This test was merged in upstream `earlgrey_1.0.0` for the purpose of some basic testing of the QEMU I2C and so needs to be added to the passing CI list here.

See relevant discussion https://github.com/lowRISC/qemu/pull/186#issuecomment-3300349549. Probably CI should be changed to make tests that unexpectedly pass non-blocking (but warn loudly), but that change can be done in a separate PR to unblock CI for now.

Edit: it turns out this test is still flaky ~10% of the time from 100 local runs (need to look into why), for now I add it as a flaky test instead.