### PR TITLE
Several script fixes and improvements

### DIFF
--- a/docs/config/opentitan/darjeeling.cfg
+++ b/docs/config/opentitan/darjeeling.cfg
@@ -1,0 +1,65 @@
+# Generated from OpenTitan 'master' branch
+# commit: f5703e1660
+
+[ot_device "ot-rom_ctrl.rom0"]
+  key = "30ae84156d37cc68063276f9e85faee1"
+  nonce = "0a553e45bab60fd5"
+
+[ot_device "ot-rom_ctrl.rom1"]
+  key = "9649127ec56c7b0e9645bf231b5b37b8"
+  nonce = "29ae80f5b440dc77"
+
+[ot_device "ot-otp-dj"]
+  digest_const = "09c87e42745452d8a010a9f0ef3221d5"
+  digest_iv = "a0806e02a1fba55b"
+  inv_default_part_15 = "58b183f3d37975b4a9524de21084a9d64bba835c10b5e29043022273f7afbf68e78e601c1704c34a6dfd043e96e1ef76d15c0798ef406091d605165216fd3f856fb88c3b4fd535bd"
+  inv_default_part_16 = "00000000696900001f2a6bd606d55f72"
+  inv_default_part_17 = "1fb5110b0618183cbf722f142ef9facfb5742826d2ce8d8bb874ddd1dbca5322ddf650f1a00008ee0000000000000000"
+  inv_default_part_18 = "2552a6aa7830346413591b15ed2553188688686a7d26f94a0000000000000000"
+  inv_default_part_19 = "eff32b59c0a86294d9767fdcb47456994c8fd64171edb20835aef32cf20b0c620e9af6c53593daec8e3caa2e495a897602e2904aa8a7090712cf9a372be9c2b9c1fbff3b68368c5afedcdee44f5d8d84276d9c42b4b5c6539c73a2705a4682baa1885457797963c3980bff063fc8bc645a7f3e2373a78aa20000000000000000"
+  inv_default_part_20 = "9c47222c695c123916e90f1bdde834c31d3eef689e998822eddeb20732f666faba37deb973d827e00000000000000000"
+  inv_default_part_21 = "6149b9ff4f5979607aead63a44f896431df745a52c5af5fdf86d2ce9fa1041c43f145a8bf5be7640d7aaf2481067180fd08f694a5f790581d728bd369d03f8087a60a7f8ed956442c9cff0f99e594c7307f376e7b2b2ff8c"
+  scrmbl_key = "d6780626a12b5904a9b37439f8177d19d04d3fad040ed02909a9ea4b5429b9e6"
+  sram_const = "4dcba329ff2f7d4b8a3acdb325087fab"
+  sram_iv = "9bd623e40aec9b61"
+
+[ot_device "ot-lc_ctrl"]
+  dev = "d2fd2987e3062f6119c7560acbbe9f6f"
+  invalid = "0d20b07721f7ff507ad2b9fb9cc7ff06"
+  lc_state_first = "eebd62140286d28089f20c8f78baa23d9210b65583a165a35342d646189f81d751c346984482681b"
+  lc_state_last = "eebde6d52eb6dbd5b9f79dcf7ebfbe3fb672bff5dfe577afd36efe6f99ffe1ff73e3779ec4fa7a9b"
+  lc_trscnt_first = "ff595454ab481e0fd02144da44cc929a4149279a202522dcf2352590ec602b24d82b42968a94dec42469cc17190a4e65"
+  lc_trscnt_last = "ff59557fbb79decfd2b776fb6fcfdf9b51f9affbad277bfcfab7a7b1ef70ebafdcebd6bebadeffc7a66fff17993a7e75"
+  ownership_first = "ea846e2884d9198c4a42348a61406249"
+  ownership_last = "fecc6faaeef93dcccefef68f696f6adf"
+  production = "ffc2171a49199bb53d8e0daa8f0578db"
+  raw_unlock_token = "e4225dc332ea1fda63b4c524556ed4d4"
+  rma = "aa5f022791480b4e709e0f80976e0966"
+  socdbg_first = "6b36fc2c"
+  socdbg_last = "ebf6fc7f"
+  test_unlocked = "e4c72c47d9e15fa8ff9f82833e32c151"
+
+[ot_device "ot-keymgr_dpe"]
+  aes_seed = "9a885419a9d57e36519fa42d20efa348cb77f5089a8381b62d9717b3647e5ce0"
+  hard_output_seed = "4d57ac27843ea2a0163efeda5b24d93f97d62d99c960542f4a1f2595192e9a96"
+  kmac_seed = "796ca68aa29523d3f94f27c74acae76b3e145326741f804e3c3a3451469c6118"
+  lfsr_seed = "488f3ffa7700ec4c"
+  none_seed = "49fcb59874cddc9cbc645d9e02a96b9980911844d3c74de85e05164b829d484b"
+  otbn_seed = "fa23bc32e428ad2be2584fe8d5491fa8e7f19aaa4133ad0d2704702ae2ff9d98"
+  revision_seed = "7b416b49b114f994a969864a57c3482ab3bdcbd9fe825728f7ba40a22c9719c5"
+  soft_output_seed = "d7c160f492d0e8757631ebf752a1e5604e2d6171f5dba9ec4249052dcc7a4d58"
+
+[ot_device "ot-ast-dj"]
+  topclocks = "main:1000000000,io:1000000000,aon:62500000"
+  aonclocks = "aon"
+
+[ot_device "ot-clkmgr"]
+  topclocks = "main:16,io:16,aon:1"
+  refclock = "aon"
+  subclocks = "io_div2:io:2,io_div4:io:4,aes:main:1,hmac:main:1,kmac:main:1,otbn:main:1"
+  groups = "powerup:aon+io+io_div2+io_div4+main,trans:aes+hmac+kmac+otbn,infra:aon+io_div4+main,secure:io_div4+main,peri:aon+io_div2+io_div4,timers:aon+io_div4"
+  swcg = "peri"
+  hint = "trans"
+
+[ot_device "ot-pwrmgr"]
+  clocks = "main,io"

--- a/docs/config/opentitan/earlgrey.cfg
+++ b/docs/config/opentitan/earlgrey.cfg
@@ -1,0 +1,68 @@
+# Generated from OpenTitan 'earlgrey_1.0.0' branch
+# commit: 1528bbce20
+
+[ot_device "ot-rom_ctrl"]
+  key = "663c291739ff0e7d644758fee1c58564"
+  nonce = "fee457dee82b6e06"
+
+[ot_device "ot-otp-eg"]
+  digest_const = "0e95f517cb98955b4d5a89aa9109294a"
+  digest_iv = "bead91d5fa4e0915"
+  flash_addr_const = "d60822e1faec5c7290c7f21f6224f027"
+  flash_addr_iv = "0b7474d640f8a7f5"
+  flash_data_const = "277195fc471e4b26b6641214b61d1b43"
+  flash_data_iv = "e048b657396b4b83"
+  inv_default_part_5 = "7edc64361898f6ff7023461f42b4a5b3f7f71ea9a9507acf17c456385a48b963a629408e450e8458f3cd636e3c9a1140ae2905da9b31bb7ac60dd16b888838df2737bacf95ed7bf8"
+  inv_default_part_6 = "6969690000000000f254e78568a7f4bb"
+  inv_default_part_7 = "024c5fee0f5c8bb2c3080ad0531facb5370ad4f5b61d71b62203a5595f131d71a060cae9543819be"
+  inv_default_part_8 = "31dc5b08ced196d3b50ff2274384b9dbdd0d4e5d6bd0177ec2dce29f8327c8dbca99e674d3996d4260d2a0790332d0552ab6973f142947235a0c88a3ea33571096c8ddc72428751c29709bbd80960ee0a80ddce593c569c4"
+  inv_default_part_9 = "8a1cd4f5518b4d2a1978b594ed3dcd94671685f41086d5d3f6f8a097aad0585e4d857adfdebd0d2c0ece8ed011c5bad01988d871b8d25f316e627ccc51fc79029f45333ca4988068edfed1b3f0968cd628a94cbb02adbb8c"
+  inv_default_part_10 = "be6f2b4a67801b852a4529345af1cdbf37e97ab260e717e8e3c3363a666c130154d936fd1163e401fadd9f8c0ee9d1a056a2719fc2c345a4873c594f465e723e64ba4e17c79665cccb7943e751f0059633fbb917e41db693"
+  scrmbl_key = "55d70063277642b5309a163990b966cd494444c3bcdf8087b7facd65e9654cd8"
+  sram_const = "4a22d4b78fe0266fbee3958332f2939b"
+  sram_iv = "f98c48b1f9377284"
+
+[ot_device "ot-lc_ctrl"]
+  dev = "90f9c5c06f733dc911a321dd4c0ac240"
+  invalid = "5bc66d10208c4fb51b97bbf4d12c378c"
+  lc_state_first = "ee75b407d2314d2ef84185ac8c990f536071632c086d4c924070be92d2948d6228b2711e9b2d8c4d"
+  lc_state_last = "ee75fe0ffe7b6f3ffc5f9ffd9ff96fdb7f736f6c9e6fdcd35277fef2d3bdcd6ffbb2f59fdf3fbedd"
+  lc_trscnt_first = "dfb6c45a241f85ce9f42229e8627462fdb02c6701242f14b41891180045c09c26c52744267c04aa055921b9461bb07da"
+  lc_trscnt_last = "dfb6f4fabf1fefcebf5ba2ffc677c6afdbabcefeb672f36b4fbdb3988dfe1be67e7e77ca77c76af7ddde3b9e7fbfe7de"
+  ownership_first = "3c61398d626885931da660ed2ab18a0f"
+  ownership_last = "bc757dbdeaf9b7d35de7e9efabfbbecf"
+  production = "6d467215dab3f2b54a52e6728678af07"
+  raw_unlock_token = "ea2b3f32cbe77554e43c8ea7ebf197c2"
+  rma = "18068e344d2eae4d73c8fa54de8aa4a4"
+  socdbg_first = "440af80d"
+  socdbg_last = "6c9ef9cf"
+  test_unlocked = "cfd6a5a5bf3032db51fa1eb92f6ce10e"
+
+[ot_device "ot-keymgr"]
+  aes_seed = "c9e662e1e1b4982b3e8eff63890dbeae926fd468a77efde3de5b4caf4776a247"
+  cdi_seed = "516c144b34c96dfabb6f6e79208a74f35c79f397c4e4c7e22b7581848a90a125"
+  creator_identity_seed = "70251696fbb4ba169a6cd82fad46a0a5c04009bb934c7ef7b83b6e40610b4309"
+  hard_output_seed = "baf4410f06dcc036fcd16fcde97d171891105dd895e3a1d0a19a16d6dbd8b20f"
+  kmac_seed = "baba4c9908ed16bc5415ec16d28c53551312fcedcf2832a66ceacf8ed4d5b616"
+  lfsr_seed = "6ca8a8225c8e1705"
+  none_seed = "4b2276bec9fc1a7a5722a9aaca4db84a32e5c6985a1a6435118b5f5f3fd3b931"
+  otbn_seed = "177dd43b56fa754e1f53ad658193b563d9bdc6d2aee84852f0cc7371ed3a6faa"
+  owner_identity_seed = "a4a7bdb05fe921615bf2ff984540f7d43ece76b4eb13363774ed2ed45545e927"
+  owner_int_identity_seed = "fcb9dc54d4276137f9901d09a76aeaa19de5c579fd38bdf38f0c21d6a52226b6"
+  revision_seed = "20bdaf59fe2ae209b8325d2c8c35fc960679b106a87e59e6aeb1b5302d334010"
+  soft_output_seed = "f6d9e4abac398d42c745eef646c1464dca86dafd7c7c71e6058ddfd871c51cac"
+
+[ot_device "ot-ast-eg"]
+  topclocks = "main:100000000,io:96000000,usb:48000000,aon:200000"
+  aonclocks = "aon"
+
+[ot_device "ot-clkmgr"]
+  topclocks = "main:500,io:480,usb:240,aon:1"
+  refclock = "aon"
+  subclocks = "io_div2:io:2,io_div4:io:4,aes:main:1,hmac:main:1,kmac:main:1,otbn:main:1"
+  groups = "powerup:aon+io+io_div2+io_div4+main+usb,trans:aes+hmac+kmac+otbn,infra:io+io_div2+io_div4+main+usb,secure:aon+io_div4+main,peri:aon+io+io_div2+io_div4+usb,timers:aon+io_div4"
+  swcg = "peri"
+  hint = "trans"
+
+[ot_device "ot-pwrmgr"]
+  clocks = "main,io,usb"

--- a/docs/opentitan/cfggen.md
+++ b/docs/opentitan/cfggen.md
@@ -12,8 +12,8 @@ the QEMU binary.
 
 ````text
 usage: cfggen.py [-h] [-T {darjeeling,earlgrey}] [-o CFG] [-c SV] [-l SV]
-                 [-t HJSON] [-s SOCID] [-C COUNT] [-a {config,clock}] [-v]
-                 [-d]
+                 [-S HJSON] [-t HJSON] [-s SOCID] [-C COUNT]
+                 [-a {config,clock}] [-x DEVICE.NAME] [-v] [-d]
                  [OTDIR]
 
 OpenTitan QEMU configuration file generator.
@@ -28,6 +28,7 @@ Files:
   -o, --out CFG         Filename of the config file to generate
   -c, --otpconst SV     OTP Constant SV file (default: auto)
   -l, --lifecycle SV    LifeCycle SV file (default: auto)
+  -S, --secrets HJSON   Secret HJSON file (default: auto)
   -t, --topcfg HJSON    OpenTitan top HJSON config file (default: auto)
 
 Modifiers:
@@ -37,6 +38,9 @@ Modifiers:
 Actions:
   -a, --action {config,clock}
                         Action(s) to perform, default: config
+  -x, --exclude DEVICE.NAME
+                        Discard any property from DEVICE that starts with NAME
+                        (may be repeated)
 
 Extras:
   -v, --verbose         increase verbosity
@@ -63,6 +67,8 @@ which can be overidden with options `-c`, `-l` and `-t`.
 * `-o` the filename of the configuration file to generate. It not specified, the generated content
   is printed out to the standard output.
 
+* `-S` path to the generated file that contains all the "secret" constants of the _top_.
+
 * `-s` specify a SoC identifier for OT platforms with mulitple SoCs
 
 * `-T` specify the OpenTitan _top_ name, such as `darjeeling`, `earlgrey`, ... This option is
@@ -72,6 +78,9 @@ which can be overidden with options `-c`, `-l` and `-t`.
 
 * `-v` can be repeated to increase verbosity of the script, mostly for debug purpose.
 
+* `-x` can be used to prevent some device properties from being emitted in the output stream. This
+  can be useful while implementing a device, whose emulation does not support the comprehensive
+  feature set of its HW counterpart.
 
 ### Examples
 
@@ -80,6 +89,8 @@ which can be overidden with options `-c`, `-l` and `-t`.
 ````
 
 ````sh
+# do not emit any 'flash*' properties for the EarlGrey OTP controller
 ./scripts/opentitan/cfggen.py -o opentitan.cfg \
     -t ../opentitan/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+    -x ot-otp-eg.flash
 ````

--- a/docs/opentitan/darjeeling.md
+++ b/docs/opentitan/darjeeling.md
@@ -108,6 +108,7 @@ any useful feature (only allow guest test code to execute as expected).
 
 ````sh
 qemu-system-riscv32 -M ot-darjeeling,no_epmp_cfg=true -display none -serial mon:stdio \
+  -readconfig docs/config/opentitan/darjeeling.cfg \
   -global ot-ibex_wrapper.lc-ignore=on -kernel hello.elf
 ````
 See the section "Useful execution options" for documentation about the `no_epmp_cfg` and
@@ -117,6 +118,7 @@ See the section "Useful execution options" for documentation about the `no_epmp_
 
 ````sh
 qemu-system-riscv32 -M ot-darjeeling -display none -serial mon:stdio \
+  -readconfig docs/config/opentitan/darjeeling.cfg \
   -object ot-rom_img,id=rom,file=rom_with_fake_keys_fpga_cw310.elf \
   -drive if=pflash,file=otp-rma.raw,format=raw \
   -drive if=mtd,bus=1,file=flash.raw,format=raw

--- a/docs/opentitan/earlgrey.md
+++ b/docs/opentitan/earlgrey.md
@@ -103,6 +103,7 @@ Some just use generic `UNIMP` devices to define a memory region.
 
 ````sh
 qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -display none -serial mon:stdio \
+  -readconfig docs/config/opentitan/earlgrey.cfg \
   -kernel hello.elf
 ````
 
@@ -112,6 +113,7 @@ See the section "Useful execution options" for documentation about the `no_epmp_
 
 ````sh
 qemu-system-riscv32 -M ot-earlgrey -display none -serial mon:stdio \
+  -readconfig docs/config/opentitan/earlgrey.cfg \
   -object ot-rom_img,id=rom,file=rom_with_fake_keys_fpga_cw310.elf \
   -drive if=pflash,file=otp-rma.raw,format=raw \
   -drive if=mtd,bus=2,file=flash.raw,format=raw

--- a/docs/opentitan/keymgr-dpe.md
+++ b/docs/opentitan/keymgr-dpe.md
@@ -42,6 +42,7 @@ Extras:
 ### Arguments
 
 * `-c` QEMU OT config file, which can be generated with the [`cfggen.py`](cfggen.md) script.
+  See also predefined files from the `docs/config/opentitan` directory.
 
 * `-d` only useful to debug the script, reports any Python traceback to the standard error stream.
 
@@ -123,12 +124,14 @@ options:
 ### Examples
 
 ````sh
-keymgr-dpe.py -vv -c ot.cfg -j otp_ctrl_mmap.hjson -m img_otp.vmem -l lc_ctrl_state_pkg.sv \
+keymgr-dpe.py -vv -c docs/config/opentitan/darjeeling.cfg \
+    -j otp_ctrl_mmap.hjson -m img_otp.vmem -l lc_ctrl_state_pkg.sv \
     -r base_rom.39.scr.hex -r second_rom.39.scr.hex -b 0 -b 0 -t AES -k 0 -s 0
 ````
 
 ````sh
-keymgr-dpe.py -vv -c ot.cfg -j otp_ctrl_mmap.hjson -m img_otp.vmem -l lc_ctrl_state_pkg.sv \
+keymgr-dpe.py -vv -c docs/config/opentitan/darjeeling.cfg \
+    -j otp_ctrl_mmap.hjson -m img_otp.vmem -l lc_ctrl_state_pkg.sv \
     -r rom0.elf -r keymgr-dpe-basic-test -z 64Ki -z 32Ki -t SW -k 0 -s 0
 ````
 

--- a/docs/opentitan/otptool.md
+++ b/docs/opentitan/otptool.md
@@ -7,13 +7,13 @@ controller virtual device.
 
 ````text
 usage: otptool.py [-h] [-j HJSON] [-m VMEM] [-l SV] [-o FILE] [-r RAW]
-                  [-k {auto,otp,fuz}] [-e BITS] [-C CONFIG] [-c INT] [-i INT]
-                  [-w] [-n] [-f PART:FIELD] [--no-version] [-s] [-E] [-D] [-U]
-                  [-g {LCVAL,LCTPL,PARTS,REGS}] [-F] [-G PART]
-                  [--change PART:FIELD=VALUE] [--empty PARTITION]
+                  [-x EXPORT] [-k {auto,otp,fuz}] [-e BITS] [-C CONFIG]
+                  [-c INT] [-i INT] [-w] [-n] [-f PART:FIELD] [--no-version]
+                  [-s] [-E] [-D] [-U] [-g {LCVAL,LCTPL,PARTS,REGS}] [-F]
+                  [-G PART] [--change PART:FIELD=VALUE] [--empty PARTITION]
                   [--erase PART:FIELD] [--clear-bit CLEAR_BIT]
                   [--set-bit SET_BIT] [--toggle-bit TOGGLE_BIT]
-                  [--patch-token NAME=VALUE] [-v] [-d]
+                  [--write ADDR/HEXBYTES] [--patch-token NAME=VALUE] [-v] [-d]
 
 QEMU OT tool to manage OTP files.
 
@@ -26,6 +26,7 @@ Files:
   -l, --lifecycle SV    input lifecycle system verilog file
   -o, --output FILE     output filename (default to stdout)
   -r, --raw RAW         QEMU OTP raw image file
+  -x, --export EXPORT   Export data to a VMEM file
 
 Parameters:
   -k, --kind {auto,otp,fuz}
@@ -60,6 +61,8 @@ Commands:
   --set-bit SET_BIT     set a bit at specified location
   --toggle-bit TOGGLE_BIT
                         toggle a bit at specified location
+  --write ADDR/HEXBYTES
+                        write bytes at specified location
   --patch-token NAME=VALUE
                         change a LC hashed token, using Rust file
 
@@ -172,6 +175,10 @@ Fuse RAW images only use the v1 type.
   contain long sequence of bytes. If repeated, the empty long fields are also printed in full, as
   a sequence of empty bytes.
 
+* `-x` export the current data and ECC content into a text file using the VMEM 24 encoding format,
+  _i.e._ 24-bit hex chunks where the first byte depicts the 6-bit ECC and the remaining two bytes
+  contain a 16-bit value.
+
 * `--clear-bit` clears the specified bit in the OTP data. This flag may be repeated. This option is
   only intended to corrupt the OTP content so that HW & SW behavior may be exercised should such
   a condition exists. See [Bit position syntax](#bit-syntax) for how to specify a bit.
@@ -216,6 +223,12 @@ Fuse RAW images only use the v1 type.
   is only intended to corrupt the OTP content so that HW & SW behavior may be exercised should such
   a condition exists. See [Bit position syntax](#bit-syntax) for how to specify a bit.
 
+* `--write` overrides any data (not ECC). If can be combined with `--fix-ecc` to automatically
+  rebuild the ECC of the data slot that have been altered. This option may be repeated. The argument
+  should comply with the `offset/hexdata` syntax, where the _offset_ part is defined in the
+  [Bit position syntax](#bit-syntax) and _hexdata_ is a byte sequence specified as a hexadecimal
+  string.
+
 All modification features can only be performed on RAW image, VMEM images are never modified. To
 modify RAW file content, either a VMEM file is required in addition to the RAW file as the data
 source, or the `-U` is required to tell that the RAW file should be read, modified and written back.
@@ -233,6 +246,10 @@ a bit is defined as `<offset>/<bit>` where `offset` is the byte offset in the OT
 
 The address is rounded down to the granule size, _e.g._ if OTP fuses are organized as 16-bit slots,
 address 2N and 2N+1 are considered the same.
+
+As a special syntax, offset may be specified as `0h...`, in which case the offset value is doubled,
+which enables to directly specify the half-word offset encoded in the input VMEM 24 file. For
+example, to write at @0006, either use `0xc` or `0h6` as the offset specifier.
 
 If the bit is larger than the data slot, it indicates the location with the ECC part, _e.g._ if OTP
 fuses are organized as 16-bit slots wtih 6-bit ECC, bit 0 to 15 indicates a bit into the data slot,

--- a/docs/opentitan/otptool.md
+++ b/docs/opentitan/otptool.md
@@ -298,7 +298,7 @@ scripts/opentitan/otptool.py -m img_rma.24.vmem -r otp.raw \
 Generate a QEMU RAW v2 image for the virtual OTP controller, here with an RMA OTP configuration,
 load Present constants from a QEMU configuration file.
 ````sh
-scripts/opentitan/otptool.py -m img_rma.24.vmem -r otp.raw -i ot.cfg
+scripts/opentitan/otptool.py -m img_rma.24.vmem -r otp.raw -i docs/config/opentitan/earlgrey.cfg
 ````
 
 Decode the content of an OTP VMEM file:

--- a/docs/opentitan/tools.md
+++ b/docs/opentitan/tools.md
@@ -35,6 +35,8 @@ of options and the available features.
 
 ## Development
 
+* [`autoregs.py`] is a Python script that generates register definitions and function templates to
+  create a QEMU system bus device emulation.
 * [`checkregs.py`](checkregs.md) is an internal tool design to check the discrepancies between
    OpenTitan generated register definition files and their QEMU counterparts. It is only useful to
    develop the machine itself.

--- a/hw/opentitan/ot_keymgr_dpe.c
+++ b/hw/opentitan/ot_keymgr_dpe.c
@@ -578,6 +578,24 @@ static const char *FST_NAMES[] = {
 #define FST_NAME(_st_) \
     (((unsigned)(_st_)) < ARRAY_SIZE(FST_NAMES) ? FST_NAMES[(_st_)] : "?")
 
+#define SEED_ENTRY(_sd_) [KEYMGR_DPE_SEED_##_sd_] = stringify(_sd_)
+static const char *SEED_NAMES[] = {
+    /* clang-format off */
+    SEED_ENTRY(LFSR),
+    SEED_ENTRY(REV),
+    SEED_ENTRY(SW_OUT),
+    SEED_ENTRY(HW_OUT),
+    SEED_ENTRY(AES),
+    SEED_ENTRY(KMAC),
+    SEED_ENTRY(OTBN),
+    SEED_ENTRY(NONE),
+    SEED_ENTRY(COUNT),
+    /* clang-format on */
+};
+#undef SEED_ENTRY
+#define SEED_NAME(_sd_) \
+    (((unsigned)(_sd_)) < ARRAY_SIZE(SEED_NAMES) ? SEED_NAMES[(_sd_)] : "?")
+
 #define OT_KEYMGR_DPE_HEXSTR_SIZE 256u
 
 #define ot_keymgr_dpe_dump_bigint(_s_, _b_, _l_) \
@@ -1962,15 +1980,15 @@ static void ot_keymgr_dpe_configure_constants(OtKeyMgrDpeState *s)
             seed_len_bytes = 8u;
         }
         if (len != (seed_len_bytes * 2u)) {
-            error_setg(&error_fatal, "%s: %s invalid seed #%u length\n",
-                       __func__, s->ot_id, ix);
+            error_setg(&error_fatal, "%s: %s invalid seed %s length: %zu\n",
+                       __func__, s->ot_id, SEED_NAME(ix), len);
             continue;
         }
 
         if (ot_common_parse_hexa_str(s->seeds[ix], s->seed_xstrs[ix],
                                      seed_len_bytes, true, true)) {
-            error_setg(&error_fatal, "%s: %s unable to parse seed #%u\n",
-                       __func__, s->ot_id, ix);
+            error_setg(&error_fatal, "%s: %s unable to parse seed %s\n",
+                       __func__, s->ot_id, SEED_NAME(ix));
             continue;
         }
     }

--- a/hw/riscv/Kconfig
+++ b/hw/riscv/Kconfig
@@ -33,6 +33,7 @@ config OT_DARJEELING
     select OT_DEV_PROXY
     select OT_DM_TL
     select OT_DMA
+    select OT_ENTROPY_SRC_DJ
     select OT_EDN
     select OT_GPIO_DJ
     select OT_HMAC
@@ -50,12 +51,13 @@ config OT_DARJEELING
     select OT_PWRMGR
     select OT_RSTMGR
     select OT_ROM_CTRL
-    select OT_SOC_PROXY
+    select OT_SOCDBG_CTRL
     select OT_SPI_DEVICE
     select OT_SPI_HOST
     select OT_SRAM_CTRL
     select OT_TIMER
     select OT_UART
+    select OT_UNIMP
     select PULP_RV_DM
     select RISCV_DM
     select RISCV_DTM

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1083,7 +1083,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "peri.io")
+            IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4")
         ),
     },
     [OT_DJ_SOC_DEV_I2C0] = {
@@ -1113,7 +1113,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "peri.io")
+            IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4")
         ),
     },
     [OT_DJ_SOC_DEV_TIMER] = {
@@ -1130,7 +1130,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "timers.io")
+            IBEX_DEV_STRING_PROP("clock-name", "timers.io_div4")
         ),
     },
     [OT_DJ_SOC_DEV_OTP_CTRL] = {
@@ -1245,7 +1245,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_UINT_PROP("n_classes", 4u),
             IBEX_DEV_UINT_PROP("n_lpg", 18u),
             IBEX_DEV_UINT_PROP("edn-ep", 4u),
-            IBEX_DEV_STRING_PROP("clock-name", "secure.io"),
+            IBEX_DEV_STRING_PROP("clock-name", "secure.io_div4"),
             IBEX_DEV_STRING_PROP("clock-name-edn", "secure.main")
         ),
     },
@@ -1280,7 +1280,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "spi0"),
             IBEX_DEV_UINT_PROP("bus-num", 0),
-            IBEX_DEV_STRING_PROP("clock-name", "peri.io"),
+            IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4"),
             IBEX_DEV_UINT_PROP("version", OT_SPI_HOST_VERSION_DJ_PRE)
         ),
     },
@@ -1323,7 +1323,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock_ctrl", AST)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clocks", "main,io,usb"),
+            IBEX_DEV_STRING_PROP("clocks", "main,io"),
             IBEX_DEV_UINT_PROP("num-rom", 2u),
             IBEX_DEV_UINT_PROP("version", OT_PWRMGR_VERSION_DJ_PRE)
         ),
@@ -1356,18 +1356,18 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock-src", AST)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("topclocks", "main:16,io:16,usb:16,aon:1"),
+            IBEX_DEV_STRING_PROP("topclocks", "main:16,io:16,aon:1"),
             IBEX_DEV_STRING_PROP("refclock", "aon"),
             IBEX_DEV_STRING_PROP("subclocks",
                 "io_div2:io:2,io_div4:io:4,"
                 "aes:main:1,hmac:main:1,kmac:main:1,otbn:main:1"),
             IBEX_DEV_STRING_PROP("groups",
-                "powerup:io_div4+aon+main+io+usb+io_div2,"
+                "powerup:aon+io+io_div2+io_div4+main,"
                 "trans:aes+hmac+kmac+otbn,"
-                "infra:io_div4+main+aon+usb+io,"
-                "secure:io_div4+main+aon,"
-                "peri:io_div4+io_div2+io+aon+usb,"
-                "timers:io_div4+aon"),
+                "infra:aon+io_div4+main,"
+                "secure:io_div4+main,"
+                "peri:aon+io_div2+io_div4,"
+                "timers:aon+io_div4"),
             IBEX_DEV_STRING_PROP("swcg", "peri"),
             IBEX_DEV_STRING_PROP("hint", "trans"),
             IBEX_DEV_UINT_PROP("version", OT_CLKMGR_VERSION_DJ_PRE)
@@ -1432,7 +1432,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "timers.io"),
+            IBEX_DEV_STRING_PROP("clock-name", "timers.io_div4"),
             IBEX_DEV_STRING_PROP("clock-name-aon", "timers.aon")
         ),
     },
@@ -1443,7 +1443,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         ),
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP("topclocks",
-                "main:1000000000,io:1000000000,usb:1000000000,aon:62500000"),
+                "main:1000000000,io:1000000000,aon:62500000"),
             IBEX_DEV_STRING_PROP("aonclocks", "aon")
         ),
     },

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -43,6 +43,7 @@
 #include "hw/opentitan/ot_dm_tl.h"
 #include "hw/opentitan/ot_dma.h"
 #include "hw/opentitan/ot_edn.h"
+#include "hw/opentitan/ot_entropy_src_dj.h"
 #include "hw/opentitan/ot_gpio_dj.h"
 #include "hw/opentitan/ot_hmac.h"
 #include "hw/opentitan/ot_i2c.h"
@@ -59,12 +60,13 @@
 #include "hw/opentitan/ot_pwrmgr.h"
 #include "hw/opentitan/ot_rom_ctrl.h"
 #include "hw/opentitan/ot_rstmgr.h"
-#include "hw/opentitan/ot_soc_proxy.h"
+#include "hw/opentitan/ot_socdbg_ctrl.h"
 #include "hw/opentitan/ot_spi_device.h"
 #include "hw/opentitan/ot_spi_host.h"
 #include "hw/opentitan/ot_sram_ctrl.h"
 #include "hw/opentitan/ot_timer.h"
 #include "hw/opentitan/ot_uart.h"
+#include "hw/opentitan/ot_unimp.h"
 #include "hw/opentitan/ot_vmapper.h"
 #include "hw/qdev-properties.h"
 #include "hw/riscv/dm.h"
@@ -105,6 +107,7 @@ enum OtDjMemoryRegion {
 };
 
 enum OtDjSocDevice {
+    OT_DJ_SOC_DEV_AC_RANGE_CHECK,
     OT_DJ_SOC_DEV_AES,
     OT_DJ_SOC_DEV_ALERT_HANDLER,
     OT_DJ_SOC_DEV_AON_TIMER,
@@ -118,6 +121,7 @@ enum OtDjSocDevice {
     OT_DJ_SOC_DEV_DTM,
     OT_DJ_SOC_DEV_EDN0,
     OT_DJ_SOC_DEV_EDN1,
+    OT_DJ_SOC_DEV_ENTROPY_SRC,
     OT_DJ_SOC_DEV_GPIO,
     OT_DJ_SOC_DEV_HART,
     OT_DJ_SOC_DEV_HMAC,
@@ -137,23 +141,24 @@ enum OtDjSocDevice {
     OT_DJ_SOC_DEV_MBX_PCIE0,
     OT_DJ_SOC_DEV_MBX_PCIE1,
     OT_DJ_SOC_DEV_OTBN,
-    OT_DJ_SOC_DEV_OTP_CTRL,
     OT_DJ_SOC_DEV_OTP_BACKEND,
+    OT_DJ_SOC_DEV_OTP_CTRL,
     OT_DJ_SOC_DEV_PINMUX,
     OT_DJ_SOC_DEV_PLIC,
     OT_DJ_SOC_DEV_PLIC_EXT,
     OT_DJ_SOC_DEV_PWRMGR,
-    OT_DJ_SOC_DEV_ROM0,
-    OT_DJ_SOC_DEV_ROM1,
+    OT_DJ_SOC_DEV_RACL_CTRL,
+    OT_DJ_SOC_DEV_ROM_CTRL0,
+    OT_DJ_SOC_DEV_ROM_CTRL1,
     OT_DJ_SOC_DEV_RSTMGR,
     OT_DJ_SOC_DEV_RV_DM,
-    OT_DJ_SOC_DEV_SENSOR_CTRL,
+    OT_DJ_SOC_DEV_SOC_DBG_CTRL,
     OT_DJ_SOC_DEV_SOC_PROXY,
     OT_DJ_SOC_DEV_SPI_DEVICE,
     OT_DJ_SOC_DEV_SPI_HOST0,
-    OT_DJ_SOC_DEV_SRAM_MAIN,
-    OT_DJ_SOC_DEV_SRAM_MBX,
-    OT_DJ_SOC_DEV_SRAM_RET,
+    OT_DJ_SOC_DEV_SRAM_CTRL_MAIN,
+    OT_DJ_SOC_DEV_SRAM_CTRL_MBOX,
+    OT_DJ_SOC_DEV_SRAM_CTRL_RET,
     OT_DJ_SOC_DEV_TAP_CTRL,
     OT_DJ_SOC_DEV_TIMER,
     OT_DJ_SOC_DEV_UART0,
@@ -269,7 +274,7 @@ enum OtDjPinmuxMioOut {
     MIO_OUT_SOC_PROXY_SOC_GPO13, /* 1 */
     MIO_OUT_SOC_PROXY_SOC_GPO14, /* 2 */
     MIO_OUT_SOC_PROXY_SOC_GPO15, /* 3 */
-    MIO_OUT_OTP_CTRL_TEST0, /* 4 */
+    MIO_OUT_OTP_MACRO_TEST0, /* 4 */
     MIO_OUT_COUNT, /* 5 */
 };
 
@@ -577,14 +582,52 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_STRING_PROP("tl_as_name", "ot-dbg")
         )
     },
+    [OT_DJ_SOC_DEV_RACL_CTRL] = {
+        .type = TYPE_OT_UNIMP,
+        .cfg = &ibex_unimp_configure,
+        .memmap = MEMMAPENTRIES(
+            { .base = 0x1461f00u }
+        ),
+        .prop = IBEXDEVICEPROPDEFS(
+            IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "racl"),
+            IBEX_DEV_UINT_PROP("size", 0x100u),
+            IBEX_DEV_UINT_PROP("irq-count", 1u),
+            IBEX_DEV_UINT_PROP("alert-count", 2u),
+            IBEX_DEV_BOOL_PROP("warn-once", true)
+        ),
+        .gpio = IBEXGPIOCONNDEFS(
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 130),
+            OT_DJ_SOC_GPIO_ALERT(0, 68),
+            OT_DJ_SOC_GPIO_ALERT(1, 69)
+        ),
+    },
+    [OT_DJ_SOC_DEV_AC_RANGE_CHECK] = {
+        .type = TYPE_OT_UNIMP,
+        .cfg = &ibex_unimp_configure,
+        .memmap = MEMMAPENTRIES(
+            { .base = 0x1464000u }
+        ),
+        .prop = IBEXDEVICEPROPDEFS(
+            IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "acr"),
+            IBEX_DEV_UINT_PROP("size", 0x400u),
+            IBEX_DEV_UINT_PROP("irq-count", 1u),
+            IBEX_DEV_UINT_PROP("alert-count", 2u),
+            IBEX_DEV_BOOL_PROP("warn-once", true)
+        ),
+        .gpio = IBEXGPIOCONNDEFS(
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 131),
+            OT_DJ_SOC_GPIO_ALERT(0, 70),
+            OT_DJ_SOC_GPIO_ALERT(1, 71)
+        ),
+    },
     [OT_DJ_SOC_DEV_AES] = {
         .type = TYPE_OT_AES,
         .memmap = MEMMAPENTRIES(
             { .base = 0x21100000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_ALERT(0, 55),
-            OT_DJ_SOC_GPIO_ALERT(1, 56)
+            OT_DJ_SOC_GPIO_ALERT(0, 24),
+            OT_DJ_SOC_GPIO_ALERT(1, 25)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR),
@@ -601,10 +644,10 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x21110000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 115),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 116),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 117),
-            OT_DJ_SOC_GPIO_ALERT(0, 57)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 77),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 78),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 79),
+            OT_DJ_SOC_GPIO_ALERT(0, 26)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
@@ -619,11 +662,11 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x21120000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 118),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 119),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 120),
-            OT_DJ_SOC_GPIO_ALERT(0, 58),
-            OT_DJ_SOC_GPIO_ALERT(1, 59)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 80),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 81),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 82),
+            OT_DJ_SOC_GPIO_ALERT(0, 27),
+            OT_DJ_SOC_GPIO_ALERT(1, 28)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR),
@@ -641,9 +684,9 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x21130000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 121),
-            OT_DJ_SOC_GPIO_ALERT(0, 60),
-            OT_DJ_SOC_GPIO_ALERT(1, 61)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 83),
+            OT_DJ_SOC_GPIO_ALERT(0, 29),
+            OT_DJ_SOC_GPIO_ALERT(1, 30)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR),
@@ -662,9 +705,9 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x21140000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 122),
-            OT_DJ_SOC_GPIO_ALERT(0, 63),
-            OT_DJ_SOC_GPIO_ALERT(1, 64)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 84),
+            OT_DJ_SOC_GPIO_ALERT(0, 31),
+            OT_DJ_SOC_GPIO_ALERT(1, 32)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("aes", AES),
@@ -673,8 +716,8 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("otbn", OTBN),
             OT_DJ_SOC_DEVLINK("lc_ctrl", LC_CTRL),
             OT_DJ_SOC_DEVLINK("otp_ctrl", OTP_CTRL),
-            OT_DJ_SOC_DEVLINK("rom0", ROM0),
-            OT_DJ_SOC_DEVLINK("rom1", ROM1)
+            OT_DJ_SOC_DEVLINK("rom0", ROM_CTRL0),
+            OT_DJ_SOC_DEVLINK("rom1", ROM_CTRL1)
         ),
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_UINT_PROP("edn-ep", 0u),
@@ -687,28 +730,68 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x21150000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 123),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 124),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 125),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 126),
-            OT_DJ_SOC_GPIO_ALERT(0, 64),
-            OT_DJ_SOC_GPIO_ALERT(1, 65)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 85),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 86),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 87),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 88),
+            OT_DJ_SOC_GPIO_ALERT(0, 33),
+            OT_DJ_SOC_GPIO_ALERT(1, 34)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("random_src", AST),
             OT_DJ_SOC_DEVLINK("otp_ctrl", OTP_CTRL)
         ),
     },
+    [OT_DJ_SOC_DEV_ENTROPY_SRC] = {
+        .type = TYPE_OT_UNIMP,
+        .cfg = &ibex_unimp_configure,
+        .memmap = MEMMAPENTRIES(
+            { .base = 0x21160000u }
+        ),
+        .prop = IBEXDEVICEPROPDEFS(
+            IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "entropy_src"),
+            IBEX_DEV_UINT_PROP("size", 0x100u),
+            IBEX_DEV_UINT_PROP("alert-count", 2u),
+            IBEX_DEV_BOOL_PROP("warn-once", true)
+        ),
+        .gpio = IBEXGPIOCONNDEFS(
+            OT_DJ_SOC_GPIO_ALERT(0, 35),
+            OT_DJ_SOC_GPIO_ALERT(1, 36)
+        ),
+    },
+    /*
+     * @todo enable DJ entropy source once implemented, replacing the above
+     *       unimplemented fake device
+     *
+     * [OT_DJ_SOC_DEV_ENTROPY_SRC] = {
+     *     .type = TYPE_OT_ENTROPY_SRC,
+     *     .memmap = MEMMAPENTRIES(
+     *      { .base = 0x21160000u }
+     *     ),
+     *     .gpio = IBEXGPIOCONNDEFS(
+     *      OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 89),
+     *      OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 90),
+     *      OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 91),
+     *      OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 92),
+     *      OT_DJ_SOC_GPIO_ALERT(0, 35),
+     *      OT_DJ_SOC_GPIO_ALERT(1, 36)
+     *     ),
+     *     .link = IBEXDEVICELINKDEFS(
+     *      OT_DJ_SOC_DEVLINK("ast", AST),
+     *      OT_DJ_SOC_DEVLINK("otp_ctrl", OTP_CTRL)
+     *     ),
+     * },
+     */
     [OT_DJ_SOC_DEV_EDN0] = {
         .type = TYPE_OT_EDN,
         .memmap = MEMMAPENTRIES(
             { .base = 0x21170000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 127),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 128),
-            OT_DJ_SOC_GPIO_ALERT(0, 66),
-            OT_DJ_SOC_GPIO_ALERT(1, 67)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 93),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 94),
+            OT_DJ_SOC_GPIO_ALERT(0, 37),
+            OT_DJ_SOC_GPIO_ALERT(1, 38)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("csrng", CSRNG)
@@ -723,10 +806,10 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x21180000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 129),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 130),
-            OT_DJ_SOC_GPIO_ALERT(0, 68),
-            OT_DJ_SOC_GPIO_ALERT(1, 69)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 95),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 96),
+            OT_DJ_SOC_GPIO_ALERT(0, 39),
+            OT_DJ_SOC_GPIO_ALERT(1, 40)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("csrng", CSRNG)
@@ -735,14 +818,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_UINT_PROP("csrng-app", 1u)
         ),
     },
-    [OT_DJ_SOC_DEV_SRAM_MAIN] = {
+    [OT_DJ_SOC_DEV_SRAM_CTRL_MAIN] = {
         .type = TYPE_OT_SRAM_CTRL,
         .memmap = MEMMAPENTRIES(
             { .base = 0x211c0000u },
-            { 0x10000000u }
+            { .base = 0x10000000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_ALERT(0, 70)
+            OT_DJ_SOC_GPIO_ALERT(0, 41)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("otp_ctrl", OTP_CTRL),
@@ -754,14 +837,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_BOOL_PROP("ifetch", true)
         ),
     },
-    [OT_DJ_SOC_DEV_SRAM_MBX] = {
+    [OT_DJ_SOC_DEV_SRAM_CTRL_MBOX] = {
         .type = TYPE_OT_SRAM_CTRL,
         .memmap = MEMMAPENTRIES(
             { .base = 0x211d0000u },
-            { 0x11000000u }
+            { .base = 0x11000000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_ALERT(0, 71)
+            OT_DJ_SOC_GPIO_ALERT(0, 42)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("otp_ctrl", OTP_CTRL),
@@ -773,14 +856,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_BOOL_PROP("ifetch", false)
         ),
     },
-    [OT_DJ_SOC_DEV_ROM0] = {
+    [OT_DJ_SOC_DEV_ROM_CTRL0] = {
         .type = TYPE_OT_ROM_CTRL,
         .memmap = MEMMAPENTRIES(
             { .base = 0x211e0000u },
-            { 0x00008000u }
+            { .base = 0x00008000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_ALERT(0, 72),
+            OT_DJ_SOC_GPIO_ALERT(0, 43),
             OT_DJ_SOC_SIGNAL(OT_ROM_CTRL_GOOD, 0, PWRMGR,
                              OT_PWRMGR_ROM_GOOD, 0),
             OT_DJ_SOC_SIGNAL(OT_ROM_CTRL_DONE, 0, PWRMGR,
@@ -797,14 +880,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_STRING_PROP("key", "f2ff984540f7d43ece76b4eb13363774")
         ),
     },
-    [OT_DJ_SOC_DEV_ROM1] = {
+    [OT_DJ_SOC_DEV_ROM_CTRL1] = {
         .type = TYPE_OT_ROM_CTRL,
         .memmap = MEMMAPENTRIES(
             { .base = 0x211e1000u },
-            { 0x00020000u }
+            { .base = 0x00020000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_ALERT(0, 73),
+            OT_DJ_SOC_GPIO_ALERT(0, 44),
             OT_DJ_SOC_SIGNAL(OT_ROM_CTRL_GOOD, 0, PWRMGR,
                              OT_PWRMGR_ROM_GOOD, 1),
             OT_DJ_SOC_SIGNAL(OT_ROM_CTRL_DONE, 0, PWRMGR,
@@ -827,10 +910,10 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x211f0000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_ALERT(0, 95),
-            OT_DJ_SOC_GPIO_ALERT(1, 96),
-            OT_DJ_SOC_GPIO_ALERT(2, 97),
-            OT_DJ_SOC_GPIO_ALERT(3, 98)
+            OT_DJ_SOC_GPIO_ALERT(0, 72),
+            OT_DJ_SOC_GPIO_ALERT(1, 73),
+            OT_DJ_SOC_GPIO_ALERT(2, 74),
+            OT_DJ_SOC_GPIO_ALERT(3, 75)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("edn", EDN0),
@@ -856,28 +939,28 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         ),
     },
     [OT_DJ_SOC_DEV_MBX0] = {
-        OT_DJ_SOC_DEV_MBX(0, 0x22000000u, "ot-mbx.sram", 134, 75),
+        OT_DJ_SOC_DEV_MBX(0, 0x22000000u, "ot-mbx.sram", 100, 46),
     },
     [OT_DJ_SOC_DEV_MBX1] = {
-        OT_DJ_SOC_DEV_MBX(1, 0x22000100u, "ot-mbx.sram", 137, 77),
+        OT_DJ_SOC_DEV_MBX(1, 0x22000100u, "ot-mbx.sram", 103, 48),
     },
     [OT_DJ_SOC_DEV_MBX2] = {
-        OT_DJ_SOC_DEV_MBX(2, 0x22000200u, "ot-mbx.sram", 140, 79),
+        OT_DJ_SOC_DEV_MBX(2, 0x22000200u, "ot-mbx.sram", 106, 50),
     },
     [OT_DJ_SOC_DEV_MBX3] = {
-        OT_DJ_SOC_DEV_MBX(3, 0x22000300u, "ot-mbx.sram", 143, 81),
+        OT_DJ_SOC_DEV_MBX(3, 0x22000300u, "ot-mbx.sram", 109, 52),
     },
     [OT_DJ_SOC_DEV_MBX4] = {
-        OT_DJ_SOC_DEV_MBX(4, 0x22000400u, "ot-mbx.sram", 146, 83),
+        OT_DJ_SOC_DEV_MBX(4, 0x22000400u, "ot-mbx.sram", 112, 54),
     },
     [OT_DJ_SOC_DEV_MBX5] = {
-        OT_DJ_SOC_DEV_MBX(5, 0x22000500u, "ot-mbx.sram", 149, 85),
+        OT_DJ_SOC_DEV_MBX(5, 0x22000500u, "ot-mbx.sram", 115, 56),
     },
     [OT_DJ_SOC_DEV_MBX6] = {
-        OT_DJ_SOC_DEV_MBX(6, 0x22000600u, "ot-mbx.sram", 152, 87),
+        OT_DJ_SOC_DEV_MBX(6, 0x22000600u, "ot-mbx.sram", 118, 58),
     },
     [OT_DJ_SOC_DEV_MBX_JTAG] = {
-        OT_DJ_SOC_DEV_MBX_DUAL(7, 0x22000800u, "ot-mbx.sram", 155, 89,
+        OT_DJ_SOC_DEV_MBX_DUAL(7, 0x22000800u, "ot-mbx.sram", 121, 60,
                                DEBUG_MEMORY(OT_DJ_DEBUG_MBX_JTAG_ADDR)),
     },
     [OT_DJ_SOC_DEV_DMA] = {
@@ -886,94 +969,22 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x22010000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 131),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 132),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 133),
-            OT_DJ_SOC_GPIO_ALERT(0, 74)
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 97),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 98),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 99),
+            OT_DJ_SOC_GPIO_ALERT(0, 45)
         ),
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP("ot_as_name", "ot-dma"),
             IBEX_DEV_STRING_PROP("ctn_as_name", "ctn-dma")
         )
     },
-
-    [OT_DJ_SOC_DEV_SOC_PROXY] = {
-        .type = TYPE_OT_SOC_PROXY,
-        .memmap = MEMMAPENTRIES(
-            { .base = 0x22030000u }
-        ),
-        .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 83),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 84),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 85),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 86),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(4, PLIC, 87),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 88),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 89),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 90),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(8, PLIC, 91),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(9, PLIC, 92),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(10, PLIC, 93),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(11, PLIC, 94),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(12, PLIC, 95),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(13, PLIC, 96),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(14, PLIC, 97),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(15, PLIC, 98),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(16, PLIC, 99),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(17, PLIC, 100),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(18, PLIC, 101),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(19, PLIC, 102),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(20, PLIC, 103),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(21, PLIC, 104),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(22, PLIC, 105),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(23, PLIC, 106),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(24, PLIC, 107),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(25, PLIC, 108),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(26, PLIC, 109),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(27, PLIC, 110),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(28, PLIC, 111),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(29, PLIC, 112),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(30, PLIC, 113),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(31, PLIC, 114),
-            OT_DJ_SOC_GPIO_ALERT(0, 23),
-            OT_DJ_SOC_GPIO_ALERT(1, 24),
-            OT_DJ_SOC_GPIO_ALERT(2, 25),
-            OT_DJ_SOC_GPIO_ALERT(3, 26),
-            OT_DJ_SOC_GPIO_ALERT(4, 27),
-            OT_DJ_SOC_GPIO_ALERT(5, 28),
-            OT_DJ_SOC_GPIO_ALERT(6, 29),
-            OT_DJ_SOC_GPIO_ALERT(7, 30),
-            OT_DJ_SOC_GPIO_ALERT(8, 31),
-            OT_DJ_SOC_GPIO_ALERT(9, 32),
-            OT_DJ_SOC_GPIO_ALERT(10, 33),
-            OT_DJ_SOC_GPIO_ALERT(11, 34),
-            OT_DJ_SOC_GPIO_ALERT(12, 35),
-            OT_DJ_SOC_GPIO_ALERT(13, 36),
-            OT_DJ_SOC_GPIO_ALERT(14, 37),
-            OT_DJ_SOC_GPIO_ALERT(15, 38),
-            OT_DJ_SOC_GPIO_ALERT(16, 39),
-            OT_DJ_SOC_GPIO_ALERT(17, 40),
-            OT_DJ_SOC_GPIO_ALERT(18, 41),
-            OT_DJ_SOC_GPIO_ALERT(19, 42),
-            OT_DJ_SOC_GPIO_ALERT(20, 43),
-            OT_DJ_SOC_GPIO_ALERT(21, 44),
-            OT_DJ_SOC_GPIO_ALERT(22, 45),
-            OT_DJ_SOC_GPIO_ALERT(23, 46),
-            OT_DJ_SOC_GPIO_ALERT(24, 47),
-            OT_DJ_SOC_GPIO_ALERT(25, 48),
-            OT_DJ_SOC_GPIO_ALERT(26, 49),
-            OT_DJ_SOC_GPIO_ALERT(27, 50),
-            OT_DJ_SOC_GPIO_ALERT(28, 51)
-        ),
-        .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "0")
-        ),
-    },
+    // todo: obsolete SOC_PROXY
     [OT_DJ_SOC_DEV_MBX_PCIE0] = {
-        OT_DJ_SOC_DEV_MBX(8, 0x22040000u, "ot-mbx.sram", 158, 91),
+        OT_DJ_SOC_DEV_MBX(8, 0x22040000u, "ot-mbx.sram", 124, 62),
     },
     [OT_DJ_SOC_DEV_MBX_PCIE1] = {
-        OT_DJ_SOC_DEV_MBX(9, 0x22040100u, "ot-mbx.sram", 161, 93),
+        OT_DJ_SOC_DEV_MBX(9, 0x22040100u, "ot-mbx.sram", 127, 64),
     },
     [OT_DJ_SOC_DEV_PLIC] = {
         .type = TYPE_SIFIVE_PLIC,
@@ -1005,7 +1016,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         ),
         .gpio = IBEXGPIOCONNDEFS(
             OT_DJ_SOC_GPIO(0, HART, IRQ_M_SOFT),
-            OT_DJ_SOC_GPIO_ALERT(0, 54)
+            OT_DJ_SOC_GPIO_ALERT(0, 23)
         ),
     },
     [OT_DJ_SOC_DEV_GPIO] = {
@@ -1014,38 +1025,38 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x30000000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 9),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 10),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 11),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 12),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(4, PLIC, 13),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 14),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 15),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 16),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(8, PLIC, 17),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(9, PLIC, 18),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(10, PLIC, 19),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(11, PLIC, 20),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(12, PLIC, 21),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(13, PLIC, 22),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(14, PLIC, 23),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(15, PLIC, 24),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(16, PLIC, 25),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(17, PLIC, 26),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(18, PLIC, 27),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(19, PLIC, 28),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(20, PLIC, 29),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(21, PLIC, 30),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(22, PLIC, 31),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(23, PLIC, 32),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(24, PLIC, 33),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(25, PLIC, 34),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(26, PLIC, 35),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(27, PLIC, 36),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(28, PLIC, 37),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(29, PLIC, 38),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(30, PLIC, 39),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(31, PLIC, 40),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 10),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 11),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 12),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 13),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(4, PLIC, 14),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 15),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 16),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 17),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(8, PLIC, 18),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(9, PLIC, 19),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(10, PLIC, 20),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(11, PLIC, 21),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(12, PLIC, 22),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(13, PLIC, 23),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(14, PLIC, 24),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(15, PLIC, 25),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(16, PLIC, 26),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(17, PLIC, 27),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(18, PLIC, 28),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(19, PLIC, 29),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(20, PLIC, 30),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(21, PLIC, 31),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(22, PLIC, 32),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(23, PLIC, 33),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(24, PLIC, 34),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(25, PLIC, 35),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(26, PLIC, 36),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(27, PLIC, 37),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(28, PLIC, 38),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(29, PLIC, 39),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(30, PLIC, 40),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(31, PLIC, 41),
             OT_DJ_SOC_GPIO_ALERT(0, 1)
         )
     },
@@ -1065,13 +1076,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 6),
             OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 7),
             OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 8),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(8, PLIC, 9),
             OT_DJ_SOC_GPIO_ALERT(0, 0)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4")
+            IBEX_DEV_STRING_PROP("clock-name", "peri.io")
         ),
     },
     [OT_DJ_SOC_DEV_I2C0] = {
@@ -1080,28 +1092,28 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x30080000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 53),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 54),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 55),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 56),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(4, PLIC, 57),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 58),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 59),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 60),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(8, PLIC, 61),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(9, PLIC, 62),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(10, PLIC, 63),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(11, PLIC, 64),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(12, PLIC, 65),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(13, PLIC, 66),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(14, PLIC, 67),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 50),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 51),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 52),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 53),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(4, PLIC, 54),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 55),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 56),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 57),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(8, PLIC, 58),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(9, PLIC, 59),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(10, PLIC, 60),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(11, PLIC, 61),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(12, PLIC, 62),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(13, PLIC, 63),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(14, PLIC, 64),
             OT_DJ_SOC_GPIO_ALERT(0, 3)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4")
+            IBEX_DEV_STRING_PROP("clock-name", "peri.io")
         ),
     },
     [OT_DJ_SOC_DEV_TIMER] = {
@@ -1111,14 +1123,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         ),
         .gpio = IBEXGPIOCONNDEFS(
             OT_DJ_SOC_GPIO(0, HART, IRQ_M_TIMER),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 68),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 65),
             OT_DJ_SOC_GPIO_ALERT(0, 4)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "timers.io_div4")
+            IBEX_DEV_STRING_PROP("clock-name", "timers.io")
         ),
     },
     [OT_DJ_SOC_DEV_OTP_CTRL] = {
@@ -1128,8 +1140,8 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x30130000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 69),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 70),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 66),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 67),
             OT_DJ_SOC_GPIO_ALERT(0, 5),
             OT_DJ_SOC_GPIO_ALERT(1, 6),
             OT_DJ_SOC_GPIO_ALERT(2, 7),
@@ -1148,7 +1160,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
     [OT_DJ_SOC_DEV_OTP_BACKEND] = {
         .type = TYPE_OT_OTP_OT_BE,
         .memmap = MEMMAPENTRIES(
-            { .base = 0x30138000u }
+            { .base = 0x30140000u }
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("parent", OTP_CTRL)
@@ -1157,7 +1169,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
     [OT_DJ_SOC_DEV_LC_CTRL] = {
         .type = TYPE_OT_LC_CTRL,
         .memmap = MEMMAPENTRIES(
-            { .base = 0x30140000u },
+            { .base = 0x30150000u },
             { .base = DEBUG_MEMORY(OT_DJ_DEBUG_LC_CTRL_ADDR) }
         ),
         .gpio = IBEXGPIOCONNDEFS(
@@ -1212,13 +1224,13 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
     [OT_DJ_SOC_DEV_ALERT_HANDLER] = {
         .type = TYPE_OT_ALERT,
         .memmap = MEMMAPENTRIES(
-            { .base = 0x30150000u }
+            { .base = 0x30160000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 71),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 72),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 73),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 74),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 68),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 69),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 70),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 71),
             OT_DJ_SOC_GPIO_ESCALATE(0, IBEX_WRAPPER, 0),
             OT_DJ_SOC_GPIO_ESCALATE(1, LC_CTRL, 0),
             OT_DJ_SOC_GPIO_ESCALATE(2, LC_CTRL, 1),
@@ -1233,9 +1245,24 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_UINT_PROP("n_classes", 4u),
             IBEX_DEV_UINT_PROP("n_lpg", 18u),
             IBEX_DEV_UINT_PROP("edn-ep", 4u),
-            IBEX_DEV_STRING_PROP("clock-name", "secure.io_div4"),
+            IBEX_DEV_STRING_PROP("clock-name", "secure.io"),
             IBEX_DEV_STRING_PROP("clock-name-edn", "secure.main")
         ),
+    },
+    [OT_DJ_SOC_DEV_SOC_DBG_CTRL] = {
+        /* @todo: should be renamed TYPE_OT_SOC_DBG_CTRL */
+        .type = TYPE_OT_SOCDBG_CTRL,
+        .memmap = MEMMAPENTRIES(
+            { .base = 0x30170000u }
+        ),
+        /*
+         * @todo: add alert signals once OT_SOC_DBG_CTRL supports them
+         *
+         * .gpio = IBEXGPIOCONNDEFS(
+         *     OT_DJ_SOC_GPIO_ALERT(0, 66),
+         *     OT_DJ_SOC_GPIO_ALERT(1, 67)
+         * ),
+         */
     },
     [OT_DJ_SOC_DEV_SPI_HOST0] = {
         .type = TYPE_OT_SPI_HOST,
@@ -1243,8 +1270,8 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x30300000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 76),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 77),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 72),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 73),
             OT_DJ_SOC_GPIO_ALERT(0, 13)
         ),
         .link = IBEXDEVICELINKDEFS(
@@ -1253,7 +1280,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "spi0"),
             IBEX_DEV_UINT_PROP("bus-num", 0),
-            IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4"),
+            IBEX_DEV_STRING_PROP("clock-name", "peri.io"),
             IBEX_DEV_UINT_PROP("version", OT_SPI_HOST_VERSION_DJ_PRE)
         ),
     },
@@ -1264,18 +1291,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x30310000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 41),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 42),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 43),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 44),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(4, PLIC, 45),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 46),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 47),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 48),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(8, PLIC, 49),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(9, PLIC, 50),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(10, PLIC, 51),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(11, PLIC, 52),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 42),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 43),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(2, PLIC, 44),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(3, PLIC, 45),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(4, PLIC, 46),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(5, PLIC, 47),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(6, PLIC, 48),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(7, PLIC, 49),
             OT_DJ_SOC_GPIO_ALERT(0, 2)
         ),
     },
@@ -1285,7 +1308,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x30400000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 78),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 74),
             OT_DJ_SOC_GPIO_ALERT(0, 14),
             OT_DJ_SOC_REQ(OT_PWRMGR_OTP, OTP_CTRL),
             OT_DJ_SOC_REQ(OT_PWRMGR_LC, LC_CTRL),
@@ -1397,8 +1420,8 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             { .base = 0x30470000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 79),
-            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 80),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(0, PLIC, 75),
+            OT_DJ_SOC_GPIO_SYSBUS_IRQ(1, PLIC, 76),
             OT_DJ_SOC_GPIO_ALERT(0, 20),
             OT_DJ_SOC_SIGNAL(OT_AON_TIMER_WKUP, 0, PWRMGR,
                              OT_PWRMGR_WKUP, OT_PWRMGR_WAKEUP_AON_TIMER),
@@ -1409,7 +1432,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock-src", CLKMGR)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("clock-name", "timers.io_div4"),
+            IBEX_DEV_STRING_PROP("clock-name", "timers.io"),
             IBEX_DEV_STRING_PROP("clock-name-aon", "timers.aon")
         ),
     },
@@ -1424,14 +1447,14 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_STRING_PROP("aonclocks", "aon")
         ),
     },
-    [OT_DJ_SOC_DEV_SRAM_RET] = {
+    [OT_DJ_SOC_DEV_SRAM_CTRL_RET] = {
         .type = TYPE_OT_SRAM_CTRL,
         .memmap = MEMMAPENTRIES(
             { .base = 0x30500000u },
             { .base = 0x30600000u }
         ),
         .gpio = IBEXGPIOCONNDEFS(
-            OT_DJ_SOC_GPIO_ALERT(0, 52)
+            OT_DJ_SOC_GPIO_ALERT(0, 21)
         ),
         .link = IBEXDEVICELINKDEFS(
             OT_DJ_SOC_DEVLINK("otp_ctrl", OTP_CTRL),
@@ -1691,10 +1714,10 @@ static void ot_dj_soc_reset_exit(Object *obj, ResetType type)
     }
 
     /* Kick off ROM checks and boot */
-    object_property_set_bool(OBJECT(s->devices[OT_DJ_SOC_DEV_ROM0]), "load",
-                             true, &error_fatal);
-    object_property_set_bool(OBJECT(s->devices[OT_DJ_SOC_DEV_ROM1]), "load",
-                             true, &error_fatal);
+    object_property_set_bool(OBJECT(s->devices[OT_DJ_SOC_DEV_ROM_CTRL0]),
+                             "load", true, &error_fatal);
+    object_property_set_bool(OBJECT(s->devices[OT_DJ_SOC_DEV_ROM_CTRL1]),
+                             "load", true, &error_fatal);
 }
 
 static void ot_dj_soc_realize(DeviceState *dev, Error **errp)
@@ -1745,7 +1768,8 @@ static void ot_dj_soc_realize(DeviceState *dev, Error **errp)
     Object *mbx_sram_oas = object_new(TYPE_OT_ADDRESS_SPACE);
     object_property_add_child(OBJECT(dev), "ot-mbx.sram", mbx_sram_oas);
     ot_address_space_set(OT_ADDRESS_SPACE(mbx_sram_oas), mbx_sram_as);
-    SysBusDevice *sram_dev = SYS_BUS_DEVICE(s->devices[OT_DJ_SOC_DEV_SRAM_MBX]);
+    SysBusDevice *sram_dev =
+        SYS_BUS_DEVICE(s->devices[OT_DJ_SOC_DEV_SRAM_CTRL_MBOX]);
     /* first MMIO maps to register, second MMIO maps to SRAM */
     MemoryRegion *mbx_sram_mr = sysbus_mmio_get_region(sram_dev, 1);
     MemoryRegion *mbx_sram_alias_mr = g_new0(MemoryRegion, 1u);

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -875,9 +875,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "rom0"),
             IBEX_DEV_UINT_PROP("size", 0x8000u),
-            IBEX_DEV_UINT_PROP("kmac-app", 2u),
-            IBEX_DEV_STRING_PROP("nonce", "a7bdb05fe921615b"),
-            IBEX_DEV_STRING_PROP("key", "f2ff984540f7d43ece76b4eb13363774")
+            IBEX_DEV_UINT_PROP("kmac-app", 2u)
         ),
     },
     [OT_DJ_SOC_DEV_ROM_CTRL1] = {
@@ -899,9 +897,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "rom1"),
             IBEX_DEV_UINT_PROP("size", 0x10000u),
-            IBEX_DEV_UINT_PROP("kmac-app", 3u),
-            IBEX_DEV_STRING_PROP("nonce", "ed2ed45545e927f6"),
-            IBEX_DEV_STRING_PROP("key", "d9e4abac398d42c745eef646c1464dca")
+            IBEX_DEV_UINT_PROP("kmac-app", 3u)
         ),
     },
     [OT_DJ_SOC_DEV_IBEX_WRAPPER] = {
@@ -1204,21 +1200,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_UINT_PROP("product_id", 0x4000u),
             IBEX_DEV_UINT_PROP("revision_id", 0x1u),
             IBEX_DEV_BOOL_PROP("volatile_raw_unlock", true),
-            IBEX_DEV_UINT_PROP("kmac-app", 1u),
-            IBEX_DEV_STRING_PROP("raw_unlock_token",
-                                 "ea2b3f32cbe77554e43c8ea7ebf197c2"),
-            IBEX_DEV_STRING_PROP("lc_state_first",
-                "ee75b407d2314d2ef84185ac8c990f536071632c"
-                "086d4c924070be92d2948d6228b2711e9b2d8c4d"),
-            IBEX_DEV_STRING_PROP("lc_state_last",
-                "ee75fe0ffe7b6f3ffc5f9ffd9ff96fdb7f736f6c"
-                "9e6fdcd35277fef2d3bdcd6ffbb2f59fdf3fbedd"),
-            IBEX_DEV_STRING_PROP("lc_trscnt_first",
-                "dfb6c45a241f85ce9f42229e8627462fdb02c6701242f14b"
-                "41891180045c09c26c52744267c04aa055921b9461bb07da"),
-            IBEX_DEV_STRING_PROP("lc_trscnt_last",
-                "dfb6f4fabf1fefcebf5ba2ffc677c6afdbabcefeb672f36b"
-                "4fbdb3988dfe1be67e7e77ca77c76af7ddde3b9e7fbfe7de")
+            IBEX_DEV_UINT_PROP("kmac-app", 1u)
         )
     },
     [OT_DJ_SOC_DEV_ALERT_HANDLER] = {

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -934,18 +934,18 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
         ),
         .prop = IBEXDEVICEPROPDEFS(
             /* topclocks property overridden in ot_eg_soc_ast_configure */
-            IBEX_DEV_STRING_PROP("topclocks", "main:240,io:240,usb:480,aon:25"),
+            IBEX_DEV_STRING_PROP("topclocks", "main:500,io:480,usb:240,aon:1"),
             IBEX_DEV_STRING_PROP("refclock", "aon"),
             IBEX_DEV_STRING_PROP("subclocks",
                 "io_div2:io:2,io_div4:io:4,"
                 "aes:main:1,hmac:main:1,kmac:main:1,otbn:main:1"),
             IBEX_DEV_STRING_PROP("groups",
-                "powerup:io_div4+aon+main+io+usb+io_div2,"
+                "powerup:aon+io+io_div2+io_div4+main+usb,"
                 "trans:aes+hmac+kmac+otbn,"
-                "infra:io_div4+main+usb+io,"
-                "secure:io_div4+main+aon,"
-                "peri:io_div4+io_div2+io+aon+usb,"
-                "timers:io_div4+aon"),
+                "infra:io+io_div2+io_div4+main+usb,"
+                "secure:aon+io_div4+main,"
+                "peri:aon+io+io_div2+io_div4+usb,"
+                "timers:aon+io_div4"),
             IBEX_DEV_STRING_PROP("swcg", "peri"),
             IBEX_DEV_STRING_PROP("hint", "trans"),
             IBEX_DEV_UINT_PROP("version", OT_CLKMGR_VERSION_EG_1_0_0)

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -545,6 +545,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
     [OT_EG_SOC_DEV_SPI_DEVICE] = {
         .type = TYPE_OT_SPI_DEVICE,
         .cfg = &ot_eg_soc_spi_device_configure,
+        .instance = IBEX_MAKE_INSTANCE_NUM(0),
         .memmap = MEMMAPENTRIES(
             { .base = 0x40050000u }
         ),
@@ -562,6 +563,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
     },
     [OT_EG_SOC_DEV_I2C0] = {
         .type = TYPE_OT_I2C,
+        .instance = IBEX_MAKE_INSTANCE_NUM(0),
         .memmap = MEMMAPENTRIES(
             { .base = 0x40080000u }
         ),
@@ -593,6 +595,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
     },
     [OT_EG_SOC_DEV_I2C1] = {
         .type = TYPE_OT_I2C,
+        .instance = IBEX_MAKE_INSTANCE_NUM(1),
         .memmap = MEMMAPENTRIES(
             { .base = 0x40090000u }
         ),
@@ -624,6 +627,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
     },
     [OT_EG_SOC_DEV_I2C2] = {
         .type = TYPE_OT_I2C,
+        .instance = IBEX_MAKE_INSTANCE_NUM(2),
         .memmap = MEMMAPENTRIES(
             { .base = 0x400a0000u }
         ),
@@ -824,6 +828,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
     },
     [OT_EG_SOC_DEV_SPI_HOST0] = {
         .type = TYPE_OT_SPI_HOST,
+        .instance = IBEX_MAKE_INSTANCE_NUM(0),
         .memmap = MEMMAPENTRIES(
             { .base = 0x40300000u }
         ),
@@ -844,6 +849,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
     },
     [OT_EG_SOC_DEV_SPI_HOST1] = {
         .type = TYPE_OT_SPI_HOST,
+        .instance = IBEX_MAKE_INSTANCE_NUM(1),
         .memmap = MEMMAPENTRIES(
             { .base = 0x40310000u }
         ),

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -781,21 +781,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
             IBEX_DEV_UINT_PROP("product_id", 0x0002u),
             IBEX_DEV_UINT_PROP("revision_id", 0x1u),
             IBEX_DEV_BOOL_PROP("volatile_raw_unlock", true),
-            IBEX_DEV_UINT_PROP("kmac-app", 1u),
-            IBEX_DEV_STRING_PROP("raw_unlock_token",
-                                 "51e6121c8694c6bc41f36e2175199296"),
-            IBEX_DEV_STRING_PROP("lc_state_first",
-                "f29f2eb011e290c9210fb1d4302b323db0e81df4"
-                "a59985e47749732c6c910d3015a62e61b0c383c1"),
-            IBEX_DEV_STRING_PROP("lc_state_last",
-                "f29f3fb41fe3d2fda7afffd676abb3ffbaeefff4"
-                "a5ffefe4ff4f7fbeed9ddff29db77ee5b7d3d7e5"),
-            IBEX_DEV_STRING_PROP("lc_trscnt_first",
-                "3cfc8321c4f818ac4d53d244a4c4631e90656423004b81ba"
-                "aa5b692c13f2f21d609b685ec45d05042876e8628a8b0dd0"),
-            IBEX_DEV_STRING_PROP("lc_trscnt_last",
-                "3cfcfb23eef99fad6f7ffb44e6ce7b5ed47767e753cbabfe"
-                "bf5fe96e77f3f35d6f9f68ffde5d5564be76fd6bfb8fcdfb")
+            IBEX_DEV_UINT_PROP("kmac-app", 1u)
         )
     },
     [OT_EG_SOC_DEV_ALERT_HANDLER] = {
@@ -1309,14 +1295,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "rom"),
             IBEX_DEV_UINT_PROP("size", 0x8000u),
-            IBEX_DEV_UINT_PROP("kmac-app", 2u),
-            /*
-             * Nonce & Key for Earlgrey 1.0.0, taken from the auto-generated
-             * `hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv`
-             * `RndCnstRomCtrlScrNonce` and `RndCnstRomCtrlScrKey` values.
-             */
-            IBEX_DEV_STRING_PROP("nonce", "fee457dee82b6e06"),
-            IBEX_DEV_STRING_PROP("key", "663c291739ff0e7d644758fee1c58564")
+            IBEX_DEV_UINT_PROP("kmac-app", 2u)
         ),
     },
     [OT_EG_SOC_DEV_IBEX_WRAPPER] = {

--- a/python/qemu/ot/lc_ctrl/const.py
+++ b/python/qemu/ot/lc_ctrl/const.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""Lifecycle helpers.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+from copy import deepcopy
+from logging import getLogger
+from typing import TextIO
+
+from ot.otp.lifecycle import OtpLifecycle
+
+
+class LcCtrlConstants:
+    """Life Cycle constant manager.
+    """
+
+    def __init__(self):
+        self._log = getLogger('lc.const')
+        self._states: dict[str, tuple[str, str]] = {}
+        self._tokens: dict[str, str] = {}
+        self._diversifiers: dict [str, str] = {}
+
+    def load_sv(self, svp: TextIO) -> None:
+        """Decode LC information from a System Verilog file.
+
+           :param svp: System Verilog stream with OTP definitions.
+        """
+        lcext = OtpLifecycle()
+        lcext.load(svp)
+        states = lcext.get_configuration('LC_STATE')
+        if not states:
+            raise ValueError('Cannot obtain LifeCycle states')
+        for raw in {s for s in states if int(s, 16) == 0}:
+            del states[raw]
+        ostates = list(states)
+        self._states['lc_state'] = ostates[0], ostates[-1]
+        self._log.info("States first: '%s', last '%s'",
+                       states[ostates[0]], states[ostates[-1]])
+        trans = lcext.get_configuration('LC_TRANSITION_CNT')
+        if not trans:
+            raise ValueError('Cannot obtain LifeCycle transitions')
+        for raw in {s for s in trans if int(s, 16) == 0}:
+            del trans[raw]
+        otrans = list(trans)
+        self._states['lc_trscnt'] = otrans[0], otrans[-1]
+        self._log.info('Transitions first: %d, last %d',
+                       int(trans[otrans[0]]),
+                       int(trans[otrans[1]]))
+        self._tokens.update(lcext.get_tokens(False, False))
+        socdbg = lcext.get_configuration('SOCDBG')
+        if socdbg:
+            for raw in {s for s in socdbg if int(s, 16) == 0}:
+                del socdbg[raw]
+            osoc = list(socdbg)
+            self._states['socdbg'] = osoc[0], osoc[-1]
+            self._log.info("Socdbg first: '%s', last '%s'",
+                           socdbg[osoc[0]], socdbg[osoc[-1]])
+        ownership = lcext.get_configuration('OWNERSHIP')
+        if ownership:
+            for raw in {s for s in ownership if int(s, 16) == 0}:
+                del ownership[raw]
+            osoc = list(ownership)
+            self._states['ownership'] = osoc[0], osoc[-1]
+            self._log.info("Ownership first: '%s', last '%s'",
+                           ownership[osoc[0]], ownership[osoc[1]])
+
+    @property
+    def states(self) -> dict[str, tuple[str, str]]:
+        """Return initial and final values for all known states.
+
+           :return: a state name indexed map with first and last states
+                    hex string values.
+        """
+        return deepcopy(self._states)
+
+    @property
+    def tokens(self) -> dict[str, str]:
+        """Return LC token values.
+        """
+        return deepcopy(self._tokens)

--- a/python/qemu/ot/otp/const.py
+++ b/python/qemu/ot/otp/const.py
@@ -8,7 +8,7 @@
 
 from binascii import hexlify, unhexlify
 from logging import getLogger
-from typing import Optional, TextIO
+from typing import Any, Optional, TextIO
 import re
 
 from ot.util.misc import camel_to_snake_case
@@ -22,12 +22,13 @@ class OtpConstants:
         self._log = getLogger('otp.const')
         self._consts: dict[str, list[str]] = {}
         self._enums: dict[str, dict[str, int]] = {}
-        self._defaults: list[Optional[bytes]] = []
+        self._inv_defaults: list[Optional[str]] = []
 
-    def load(self, svp: TextIO):
-        """Decode OTP information.
+    def load_sv(self, svp: TextIO) -> bool:
+        """Decode OTP information from a System Verilog file.
 
            :param svp: System Verilog stream with OTP definitions.
+           :return: True if some OTP information has been detected
         """
         svdata = svp.read()
         for smo in re.finditer(r"\stypedef\s+enum\s+logic\s+\[[^]]+\]\s"
@@ -65,8 +66,8 @@ class OtpConstants:
                 consts.append(hexa_str)
             # RTL order in array is reversed
             consts.reverse()
-        #  +parameter +logic +\[\d+:0\] +PartInvDefault += +\d+'\(\{(.*)\}\);
         inv_default = []
+        total_byte_count = 0
         for imo in re.finditer(r"(?s) +parameter +logic +\[\d+:0\] +"
                                r"PartInvDefault += +(\d+)'\(\{(.*)\}\);",
                                svdata):
@@ -97,7 +98,7 @@ class OtpConstants:
             raise RuntimeError('Invalid partition default bytes')
         # RTL order is last-to-first
         inv_default.reverse()
-        self._defaults.clear()
+        self._inv_defaults.clear()
         for pno, part_chunks in enumerate(inv_default):
             last_part = pno == len(inv_default) - 1
             # last partition does not have digest,
@@ -107,10 +108,89 @@ class OtpConstants:
             else:
                 check_chunks = part_chunks
             if not any(any(c) for c in check_chunks):
-                self._defaults.append(None)
+                self._inv_defaults.append(None)
                 continue
             defaults = b''.join(bytes(reversed(c)) for c in part_chunks)
-            self._defaults.append(defaults)
+            self._inv_defaults.append(hexlify(defaults).decode())
+        return any(self._inv_defaults) and any(self._consts)
+
+    def load_secrets(self, secrets: dict[str, Any]) -> bool:
+        """Load OTP secrets from a (HJSON) map.
+
+           :param secrets: secret definitions as a map
+        """
+        modules = secrets.get('module', [])
+        otp: Optional[dict] = None
+        for mod in modules:
+            if mod.get('type') == 'otp_ctrl':
+                otp = mod
+                break
+        if not otp:
+            raise ValueError('Cannot locate OTP secrets')
+
+        try:
+            otp_map = otp['otp_mmap']
+            otp_size = otp_map['otp']['size']
+            scrambling = otp_map['scrambling']
+            parts = otp_map['partitions']
+        except KeyError as exc:
+            raise ValueError(f'Cannot find partition secrets: {exc}') from exc
+
+        sizes = {kp[0]: v for k, v in scrambling.items()
+                 if (kp := k.split('_', 1))[-1] == 'size'}
+        self._consts['key'] = [
+            hexlify(kv.to_bytes(sizes['key'], 'big')).decode()
+            for kd in scrambling['keys']
+            for kn, kv in kd.items() if kn =='value'
+        ]
+        self._consts['digest_const'] = [
+            hexlify(kv.to_bytes(sizes['cnst'], 'big')).decode()
+            for kd in scrambling['digests']
+            for kn, kv in kd.items() if kn =='cnst_value'
+        ]
+        self._consts['digest_iv'] = [
+            hexlify(kv.to_bytes(sizes['iv'], 'big')).decode()
+            for kd in scrambling['digests']
+            for kn, kv in kd.items() if kn =='iv_value'
+        ]
+
+        offset = 0
+        total_size = 0
+        for part in parts or []:
+            part_name = part['name']
+            part_size = 0
+            part_inv_bytes: list[bytes] = []
+            part_inv_sum = 0
+            for item in part['items']:
+                size = item['size']
+                name = item['name']
+                part_size += size
+                if item['offset'] != offset:
+                    missing = item['offset'] - offset
+                    self._log.info('Gap before %s.%s: %u bytes',
+                                   part_name, name, missing)
+                    assert missing > 0, 'Invalid negative offset'
+                    part_inv_bytes[-1] = b''.join((part_inv_bytes[-1],
+                                                   bytes(missing)))
+                    part_size += missing
+                offset = item['offset'] + size
+                inv_default = item['inv_default']
+                inv_bytes = inv_default.to_bytes(size, 'big')
+                if inv_default and not item['isdigest']:
+                    part_inv_sum += inv_default
+                part_inv_bytes.append(inv_bytes)
+            if part_size != part['size']:
+                raise ValueError(f'Invalid byte count for part {part_name}: '
+                                 f"{part_size} != {part['size']}")
+            if part_inv_sum:
+                part_inv_str = hexlify(b''.join(part_inv_bytes)).decode()
+                self._inv_defaults.append(part_inv_str)
+            else:
+                self._inv_defaults.append(None)
+            total_size += part_size
+        if total_size != otp_size:
+            raise ValueError(f'Invalid byte count for OTP '
+                             f'{total_size} != {otp_size}')
 
     def get_enums(self) -> list[str]:
         """Return a list of parsed enumerations."""
@@ -141,19 +221,16 @@ class OtpConstants:
                 odict[oname] = values[idx]
         return odict
 
-    def get_partition_inv_defaults(self, partition: int) -> Optional[list[str]]:
+    def get_partition_inv_defaults(self, partition: int) -> Optional[str]:
         """Return the invalid default values for a partition, if any.
-           Partition with only digest defaults are considered without default
+           Partitions with only digest defaults are considered without default
            values.
 
            :param partition: the partition index
-           :return: either None or the default hex-encoded bytes, including the
-                    digest
+           :return: either None or the default hex-encoded bytes, including any
+                    digest and zero-ing trailing bytes
         """
         try:
-            defaults = self._defaults[partition]
-            if not defaults:
-                return defaults
-            return hexlify(defaults).decode()
+            return self._inv_defaults[partition]
         except IndexError as exc:
             raise ValueError(f'No such partition:{partition}') from exc

--- a/python/qemu/ot/otp/image.py
+++ b/python/qemu/ot/otp/image.py
@@ -10,7 +10,8 @@ from binascii import unhexlify
 from configparser import ConfigParser, NoOptionError
 from io import BytesIO
 from logging import getLogger
-from struct import calcsize as scalc, pack as spack, unpack as sunpack
+from struct import (calcsize as scalc, iter_unpack as iunpack, pack as spack,
+                    unpack as sunpack)
 from typing import Any, BinaryIO, Optional, Sequence, TextIO, Union
 import re
 
@@ -73,6 +74,7 @@ class OtpImage:
         self._partitions: list[OtpPartition] = []
         self._part_offsets: list[int] = []
         self._dirty_offsets: list[int] = []
+        self._header_comments: list[str] = []
 
     @property
     def version(self) -> int:
@@ -157,11 +159,14 @@ class OtpImage:
             if vkind is None:
                 kmo = re.match(self.RE_VMEMDESC, line)
                 if kmo:
+                    self._header_comments.append(line.rstrip())
                     vkind = kmo.group(1)
                     row_count = int(kmo.group(2))
                     bits = int(kmo.group(3))
                     byte_count = bits // 8
                     continue
+            if line.startswith('// '):
+                self._header_comments.append(line.rstrip())
             line = re.sub(r'//.*', '', line)
             line = line.strip()
             if not line:
@@ -213,6 +218,14 @@ class OtpImage:
             raise ValueError('Unable to detect VMEM find, please specify')
         self._magic = f'v{vkind[:3].upper()}'.encode()
         self._changed = False
+
+    def save_vmem(self, vfp: TextIO) -> None:
+        """Save a VMEM '24' text stream."""
+        dsrc = iunpack('<H', self._data)
+        if self._header_comments:
+            print('\n'.join(self._header_comments), file=vfp)
+        for addr, (dword, ecc) in enumerate(zip(dsrc, self._ecc)):
+            print(f'@{addr:06x} {ecc:02x}{dword[0]:04x}', file=vfp)
 
     def load_lifecycle(self, lcext: OtpLifecycleExtension) -> None:
         """Load lifecyle values."""
@@ -456,6 +469,22 @@ class OtpImage:
         part.erase_field(field)
         self._reload(partix, True)
 
+    def change_data(self, addr: int, value: bytes) -> None:
+        """Change an arbitrary sequence of data bytes.
+
+           :param addr: address of the first byte to change
+           :param value: the new data bytes (full replacement)
+        """
+        end = addr + len(value)
+        if end > len(self._data):
+            raise ValueError(f'Invalid address/length: [0x{addr:x}..0x{end:x}] '
+                             f'beyond 0x{len(self._data):x}')
+        self._data[addr:end] = value
+        addr &= ~(self._ecc_granule - 1)
+        for pos in range(addr, end, self._ecc_granule):
+            self._dirty_offsets.append(pos)
+        self._changed = True
+
     def build_digest(self, partition: Union[int, str], erase: bool) -> None:
         """Rebuild the digest of a partition from its content.
 
@@ -494,7 +523,7 @@ class OtpImage:
             self._log.critical('Incoherent ECC size w/ granule %d',
                                granule)
         try:
-            ecc_fn = getattr(self, f'_decode_ecc_{bitcount}_{bitgran}')
+            ecc_fn = getattr(self.__class__, f'decode_ecc_{bitcount}_{bitgran}')
         except AttributeError as exc:
             raise NotImplementedError('ECC function for {self._ecc.bits}'
                                       'not supported') from exc
@@ -570,7 +599,8 @@ class OtpImage:
         bitgran = granule * 8
         bitcount = bitgran + self._ecc_bits
         try:
-            ecc_fn = getattr(self, f'_compute_ecc_{bitcount}_{bitgran}')
+            ecc_fn = getattr(self.__class__,
+                             f'compute_ecc_{bitcount}_{bitgran}')
         except AttributeError as exc:
             raise NotImplementedError('ECC function for {self._ecc.bits}'
                                       'not supported') from exc
@@ -587,18 +617,24 @@ class OtpImage:
         self._dirty_offsets.clear()
         return dirty_len
 
-    def _compute_ecc_22_16(self, data: int) -> int:
+    @classmethod
+    def compute_ecc_22_16(cls, data: int) -> int:
+        """Generate the 6-bit ECC value from a 16-bit word.
 
-        data |= self.bit_parity(data & 0x00ad5b) << 16
-        data |= self.bit_parity(data & 0x00366d) << 17
-        data |= self.bit_parity(data & 0x00c78e) << 18
-        data |= self.bit_parity(data & 0x0007f0) << 19
-        data |= self.bit_parity(data & 0x00f800) << 20
-        data |= self.bit_parity(data & 0x1fffff) << 21
+           :param data: 16-bit word
+           :return: 6-bit ECC
+        """
+        data |= cls.bit_parity(data & 0x00ad5b) << 16
+        data |= cls.bit_parity(data & 0x00366d) << 17
+        data |= cls.bit_parity(data & 0x00c78e) << 18
+        data |= cls.bit_parity(data & 0x0007f0) << 19
+        data |= cls.bit_parity(data & 0x00f800) << 20
+        data |= cls.bit_parity(data & 0x1fffff) << 21
 
         return (data & 0x3f0000) >> 16
 
-    def _decode_ecc_22_16(self, data: int, ecc: int) -> tuple[int, int]:
+    @classmethod
+    def decode_ecc_22_16(cls, data: int, ecc: int) -> tuple[int, int]:
         """Check and fix 16-bit data with 6 bits ECC.
 
            :param data: a 16-bit integer
@@ -611,10 +647,10 @@ class OtpImage:
 
         idata = data | (ecc << 16)
 
-        synd_mask, synd_code = self.SYNDROME_HAMMING_22_16
+        synd_mask, synd_code = cls.SYNDROME_HAMMING_22_16
 
         syndrome = sum(1 << b for b, m in enumerate(synd_mask)
-                       if self.bit_parity(idata & m))
+                       if cls.bit_parity(idata & m))
 
         err = (syndrome >> 5) & 1
         if not err:

--- a/python/qemu/ot/otp/secret.py
+++ b/python/qemu/ot/otp/secret.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""OTP secret helpers.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+from typing import Any, Optional, Union
+import re
+
+from ot.util.misc import camel_to_snake_case
+
+OtParamRegex = str
+"""Definition of a parameter to seek and how to shorten it."""
+
+
+class OtpSecretConstants:
+    """OTP secret constant helper.
+    """
+
+    @classmethod
+    def load_values(cls, module: dict[str, Any],
+                    odict: Union[dict[str, str],
+                                 dict[Optional[int], dict[str, str]]],
+                    multi: bool, *regexes: tuple[OtParamRegex, ...]) \
+            -> None:
+        """Load values from OTP secret dictionary.
+
+           :param module: the OTP secret module source
+           :param odict: output dictionary. If multi is false, a simple
+                         key-value map is generated, otherwise a map of indices
+                         as keys for a sub dictionary of key-values is generated
+           :param multi: whether to generate a single level or index-based map.
+           :param regexes: one of more regular expression to match in the
+                           input module. First group define the part of the
+                           matched entry to keep as key names, which are
+                           converted to snake cases.
+        """
+        modname = module.get('name')
+        if not modname:
+            return
+        for params in module.get('param_list', []):
+            if not isinstance(params, dict):
+                continue
+            for regex in regexes:
+                pmo = re.match(regex, params['name'])
+                if not pmo:
+                    continue
+                value = params.get('default')
+                if not value:
+                    continue
+                if value.startswith('0x'):
+                    value = value[2:]
+                if len(value) & 1:
+                    value = f'0{value}'
+                kname = camel_to_snake_case(pmo.group(1))
+                if multi:
+                    imo = re.search(r'(\d+)$', modname)
+                    idx = int(imo.group(1)) if imo else None
+                    if idx not in odict:
+                        odict[idx] = {}
+                    odict[idx][kname] = value
+                else:
+                    odict[kname] = value

--- a/python/qemu/ot/pyot/__init__.py
+++ b/python/qemu/ot/pyot/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-"""OpenTitan QEMU unit test sequencer.
+"""OpenTitan unit test sequencer.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """

--- a/python/qemu/ot/pyot/context.py
+++ b/python/qemu/ot/pyot/context.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-"""Test context for QEMU unit test sequencer.
+"""Test context for OpenTitan unit test sequencer.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """
@@ -15,30 +15,27 @@ from typing import Optional
 
 import re
 
-from .filemgr import QEMUFileManager
 from .util import LogMessageClassifier
-from .worker import QEMUContextWorker
+from .worker import ContextWorker
 
 
-class QEMUContext:
-    """Execution context for QEMU session.
+class ExecContext:
+    """Execution context for test executer session.
 
-       Execute commands before, while and after QEMU executes.
+       Execute commands before, while and after test executer runs.
 
-       :param test_name: the name of the test QEMU should execute
-       :param qfm: the file manager
-       :param qemu_cmd: the command and argument to execute QEMU
+       :param test_name: the name of the test executer should execute
+       :param ex_cmd: the host command and argument to execute the test
        :param context: the contex configuration for the current test
     """
 
-    def __init__(self, test_name: str, qfm: QEMUFileManager,
-                 qemu_cmd: list[str], context: dict[str, list[str]],
+    def __init__(self, test_name: str, ex_cmd: list[str],
+                 context: dict[str, list[str]],
                  env: Optional[dict[str, str]] = None):
         # pylint: disable=too-many-arguments
         self._clog = getLogger('pyot.ctx')
         self._test_name = test_name
-        self._qfm = qfm
-        self._qemu_cmd = qemu_cmd
+        self._ex_cmd = ex_cmd
         self._context = context
         self._env = env or {}
         self._workers: list[Popen] = []
@@ -72,8 +69,8 @@ class QEMUContext:
             return
         env = dict(environ)
         env.update(self._env)
-        if self._qemu_cmd:
-            env['PATH'] = ':'.join((env['PATH'], dirname(self._qemu_cmd[0])))
+        if self._ex_cmd:
+            env['PATH'] = ':'.join((env['PATH'], dirname(self._ex_cmd[0])))
         if ctx:
             for cmd in ctx:
                 bkgnd = ctx_name == 'with'
@@ -100,7 +97,7 @@ class QEMUContext:
                                     for p in rcmd.split(' '))
                     self._clog.info('Execute "%s" in background for [%s] '
                                     'context', rcmd, ctx_name)
-                    worker = QEMUContextWorker(cmd, env, sync)
+                    worker = ContextWorker(cmd, env, sync)
                     worker.run()
                     self._workers.append(worker)
                 else:

--- a/python/qemu/ot/pyot/executer.py
+++ b/python/qemu/ot/pyot/executer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-"""Test executer for QEMU unit test sequencer.
+"""Test executer for OpenTitan unit test sequencer.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """
@@ -29,10 +29,10 @@ from . import DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_FACTOR
 from .context import ExecContext
 from .filemgr import FileManager
 from .util import TestResult
-from .wrapper import QEMUWrapper
+from .wrapper import Wrapper
 
 
-class QEMUExecuter:
+class Executer:
     """Test execution sequencer.
 
        :param tfm: file manager that tracks temporary files
@@ -45,14 +45,14 @@ class QEMUExecuter:
         1: 'ERROR',
         6: 'ABORT',
         11: 'CRASH',
-        QEMUWrapper.GUEST_ERROR_OFFSET - 1: 'GUEST_ESC',
-        QEMUWrapper.GUEST_ERROR_OFFSET + 1: 'FAIL',
+        Wrapper.GUEST_ERROR_OFFSET - 1: 'GUEST_ESC',
+        Wrapper.GUEST_ERROR_OFFSET + 1: 'FAIL',
         98: 'UNEXP_SUCCESS',
         99: 'CONTEXT',
         124: 'TIMEOUT',
         125: 'DEADLOCK',
         126: 'CONTEXT',
-        QEMUWrapper.NO_MATCH_RETURN_CODE: 'UNKNOWN',
+        Wrapper.NO_MATCH_RETURN_CODE: 'UNKNOWN',
     }
 
     DEFAULT_START_DELAY = 1.0
@@ -96,7 +96,7 @@ class QEMUExecuter:
 
            :raise ValueError: if some argument is invalid
         """
-        exec_info = self._build_qemu_command(self._args)
+        exec_info = self._build_command(self._args)
         self._qemu_cmd = exec_info.command
         self._argdict = dict(self._args.__dict__)
         self._suffixes = []
@@ -121,7 +121,7 @@ class QEMUExecuter:
            :return: success or the code of the first encountered error
         """
         log_classifiers = self._config.get('logclass', {})
-        qot = QEMUWrapper(log_classifiers, debug)
+        qot = Wrapper(log_classifiers, debug)
         ret = 0
         results = defaultdict(int)
         result_file = self._argdict.get('result')
@@ -169,7 +169,7 @@ class QEMUExecuter:
                         'UTFILE': basename(test),
                     })
                     test_name = self.get_test_radix(test)
-                    exec_info = self._build_qemu_test_command(test)
+                    exec_info = self._build_test_command(test)
                     exec_info.test_name = test_name
                     vcplogfile = self._log_vcp_streams(exec_info)
                     exec_info.context.execute('pre')
@@ -276,240 +276,15 @@ class QEMUExecuter:
             for filename in files:
                 delete_file(filename)
 
-    def _build_qemu_fw_args(self, args: Namespace) \
-            -> tuple[str, Optional[str], list[str], Optional[str]]:
-        rom_exec = bool(args.rom_exec)
-        roms = args.rom or []
-        # rom can be specified as a string or a list of strings
-        if isinstance(roms, str):
-            roms = [roms]
-        multi_rom = (len(roms) + int(rom_exec)) > 1
-        # generate pre-application ROM option
-        fw_args: list[str] = []
-        machine = args.machine
-        variant = args.variant
-        chiplet_count = 1
-        if variant:
-            machine = f'{machine},variant={variant}'
-            try:
-                chiplet_count = sum(int(x)
-                                    for x in re.split(r'[A-Za-z]', variant)
-                                    if x)
-            except ValueError:
-                self._log.warning('Unknown variant syntax %s', variant)
-        rom_counts: list[int] = [0]
-        for chip_id in range(chiplet_count):
-            rom_count = 0
-            for rom in roms:
-                if rom in ('-', '_'):
-                    # special marker to disable a specific ROM
-                    rom_count += 1
-                    continue
-                rom_path = self._tfm.interpolate(rom)
-                if not isfile(rom_path):
-                    raise ValueError(f'Unable to find ROM file {rom_path}')
-                rom_ids = []
-                if args.first_soc:
-                    if chiplet_count == 1:
-                        rom_ids.append(f'{args.first_soc}.')
-                    else:
-                        rom_ids.append(f'{args.first_soc}{chip_id}.')
-                rom_ids.append('rom')
-                if multi_rom:
-                    rom_ids.append(f'{rom_count}')
-                rom_id = ''.join(rom_ids)
-                rom_opt = f'ot-rom_img,id={rom_id},file={rom_path}'
-                fw_args.extend(('-object', rom_opt))
-                rom_count += 1
-            rom_counts.append(rom_count)
-        rom_count = max(rom_counts)
-        xtype = None
-        if args.exec:
-            exec_path = self._virtual_tests.get(args.exec)
-            if not exec_path:
-                exec_path = self.abspath(args.exec)
-            xtype = guess_file_type(exec_path)
-            if xtype == 'spiflash':
-                fw_args.extend(('-drive',
-                                f'if=mtd,id=spiflash,bus=0,format=raw,'
-                                f'file={exec_path}'))
-            elif xtype == 'bin':
-                if args.embedded_flash is None:
-                    raise ValueError(f'{xtype} test type not supported without '
-                                     f'embedded-flash option')
-            else:
-                if xtype != 'elf':
-                    raise ValueError(f'No support for test type: '
-                                     f'{xtype.upper()}')
-                if rom_exec:
-                    # generate ROM option(s) for the application itself
-                    for chip in range(chiplet_count):
-                        rom_id_parts = []
-                        if args.first_soc:
-                            if chiplet_count == 1:
-                                rom_id_parts.append(f'{args.first_soc}.')
-                            else:
-                                rom_id_parts.append(f'{args.first_soc}{chip}.')
-                        rom_id_parts.append('rom')
-                        if multi_rom:
-                            rom_id_parts.append(f'{rom_count}')
-                        rom_id = ''.join(rom_id_parts)
-                        rom_opt = f'ot-rom_img,id={rom_id},file={exec_path}'
-                        fw_args.extend(('-object', rom_opt))
-                    rom_count += 1
-                else:
-                    if args.embedded_flash is None:
-                        if not roms:
-                            fw_args.extend(('-kernel', exec_path))
-                        else:
-                            fw_args.extend(('-device',
-                                            f'loader,file={exec_path}'))
-        else:
-            exec_path = None
-        return machine, xtype, fw_args, exec_path
+    def _build_command(self, args: Namespace,
+                       opts: Optional[list[str]] = None) -> EasyDict[str, Any]:
+        raise NotImplementedError('Abstact command')
 
-    def _build_qemu_log_sources(self, args: Namespace) -> list[str]:
-        if not args.log:
-            return []
-        log_args = []
-        for arg in args.log:
-            if arg.lower() == arg:
-                log_args.append(arg)
-                continue
-            for upch in arg:
-                try:
-                    logname = self.LOG_SHORTCUTS[upch]
-                except KeyError as exc:
-                    raise ValueError(f"Unknown log name '{upch}'") from exc
-                log_args.append(logname)
-        return ['-d', ','.join(log_args)]
-
-    def _build_qemu_vcp_args(self, args: Namespace) -> \
-            tuple[list[str], dict[str, tuple[str, int]]]:
-        device = args.device
-        devdesc = device.split(':')
-        host = devdesc[0]
-        try:
-            port = int(devdesc[1])
-            if not 0 < port < 65536:
-                raise ValueError(f'Invalid serial TCP port: {port}')
-        except IndexError as exc:
-            raise ValueError(f'TCP port not specified: {device}') from exc
-        except TypeError as exc:
-            raise ValueError(f'Invalid TCP serial device: {device}') from exc
-        mux = f'mux={"on" if args.muxserial else "off"}'
-        vcps = args.vcp or [self.DEFAULT_SERIAL_PORT]
-        vcp_args = ['-display', 'none']
-        vcp_map = {}
-        for vix, vcp in enumerate(vcps):
-            vcp_map[vcp] = (host, port+vix)
-            vcp_args.extend(('-chardev',
-                             f'socket,id={vcp},host={host},port={port+vix},'
-                             f'{mux},server=on,wait=on'))
-            if vcp == self.DEFAULT_SERIAL_PORT:
-                vcp_args.extend(('-serial', 'chardev:serial0'))
-        return vcp_args, vcp_map
-
-    def _build_qemu_command(self, args: Namespace,
-                            opts: Optional[list[str]] = None) \
-            -> EasyDict[str, Any]:
-        """Build QEMU command line from argparser values.
-
-           :param args: the parsed arguments
-           :param opts: any QEMU-specific additional options
-           :return: a dictionary defining how to execute the command
-        """
-        if args.qemu is None:
-            raise ValueError('QEMU path is not defined')
-        machine, xtype, fw_args, xexec = self._build_qemu_fw_args(args)
-        qemu_args = [args.qemu, '-M', machine]
-        for otcfg in args.otcfg or []:
-            qemu_args.extend(('-readconfig', self.abspath(otcfg)))
-        qemu_args.extend(fw_args)
-        temp_files = defaultdict(set)
-        if all((args.otp, args.otp_raw)):
-            raise ValueError('OTP VMEM and RAW options are mutually exclusive')
-        if args.otp:
-            if not isfile(args.otp):
-                raise ValueError(f'No such OTP file: {args.otp}')
-            otp_file = self._tfm.create_otp_image(args.otp)
-            temp_files['otp'].add(otp_file)
-            qemu_args.extend(('-drive',
-                              f'if=pflash,file={otp_file},format=raw'))
-        elif args.otp_raw:
-            otp_raw_path = self.abspath(args.otp_raw)
-            qemu_args.extend(('-drive',
-                              f'if=pflash,file={otp_raw_path},format=raw'))
-        if args.flash:
-            if xtype == 'spiflash':
-                raise ValueError('Cannot use a flash file with a flash test')
-            if not isfile(args.flash):
-                raise ValueError(f'No such flash file: {args.flash}')
-            if any((args.exec, args.boot)):
-                raise ValueError('Flash file argument is mutually exclusive '
-                                 'with bootloader or rom extension')
-            flash_path = self.abspath(args.flash)
-            if args.embedded_flash is None:
-                raise ValueError('Embedded flash bus not defined')
-            qemu_args.extend(('-drive', f'if=mtd,id=eflash,'
-                                        f'bus={args.embedded_flash},'
-                                        f'file={flash_path},format=raw'))
-        elif any((xexec, args.boot)):
-            if xexec and not isfile(xexec):
-                raise ValueError(f'No such exec file: {xexec}')
-            if args.boot and not isfile(args.boot):
-                raise ValueError(f'No such bootloader file: {args.boot}')
-            if args.embedded_flash is not None:
-                no_flash_header = args.no_flash_header
-                flash_file = self._tfm.create_eflash_image(xexec, args.boot,
-                                                           no_flash_header)
-                temp_files['flash'].add(flash_file)
-                qemu_args.extend(('-drive', f'if=mtd,id=eflash,'
-                                            f'bus={args.embedded_flash},'
-                                            f'file={flash_file},format=raw'))
-        if args.qemu_log:
-            qemu_args.extend(('-D', self.abspath(args.qemu_log)))
-        for trace in args.trace or []:
-            qemu_args.append('-trace')
-            if isfile(trace):
-                qemu_args.append(f'events={self.abspath(trace)}')
-            else:
-                qemu_args.append(trace)
-        qemu_args.extend(self._build_qemu_log_sources(args))
-        if args.singlestep:
-            qemu_args.extend(('-accel', 'tcg,one-insn-per-tb=on'))
-        if 'icount' in args:
-            if args.icount is not None:
-                qemu_args.extend(('-icount', f'shift={args.icount}'))
-        try:
-            start_delay = float(getattr(args, 'start_delay') or
-                                self.DEFAULT_START_DELAY)
-        except ValueError as exc:
-            raise ValueError(f'Invalid start up delay {args.start_delay}') \
-                from exc
-        start_delay *= args.timeout_factor
-        trigger = getattr(args, 'trigger', '')
-        validate = getattr(args, 'validate', '')
-        if trigger and validate:
-            raise ValueError(f"{getattr(args, 'exec', '?')}: 'trigger' and "
-                             f"'validate' are mutually exclusive")
-        asan = getattr(args, 'asan', False)
-        logfile = getattr(args, 'log_file', None)
-        vcp_args, vcp_map = self._build_qemu_vcp_args(args)
-        qemu_args.extend(vcp_args)
-        qemu_args.extend(args.global_opts or [])
-        if opts:
-            qemu_args.extend((str(o) for o in opts))
-        return EasyDict(command=qemu_args, vcp_map=vcp_map,
-                        tmpfiles=temp_files, start_delay=start_delay,
-                        trigger=trigger, validate=validate, asan=asan,
-                        logfile=logfile)
-
-    def _build_qemu_test_command(self, filename: str) -> EasyDict[str, Any]:
+    def _build_test_command(self, filename: str) -> EasyDict[str, Any]:
         test_name = self.get_test_radix(filename)
         args, opts, timeout, texp = self._build_test_args(test_name)
         setattr(args, 'exec', filename)
-        exec_info = self._build_qemu_command(args, opts)
+        exec_info = self._build_command(args, opts)
         exec_info.pop('connection', None)
         exec_info.args = args
         exec_info.context = self._build_test_context(test_name)

--- a/python/qemu/ot/pyot/executer.py
+++ b/python/qemu/ot/pyot/executer.py
@@ -23,11 +23,11 @@ import sys
 
 from ot.util.file import guess_file_type
 from ot.util.log import flush_memory_loggers
-from ot.util.misc import EasyDict
+from ot.util.misc import EasyDict, flatten
 
 from . import DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_FACTOR
-from .context import QEMUContext
-from .filemgr import QEMUFileManager
+from .context import ExecContext
+from .filemgr import FileManager
 from .util import TestResult
 from .wrapper import QEMUWrapper
 
@@ -35,7 +35,7 @@ from .wrapper import QEMUWrapper
 class QEMUExecuter:
     """Test execution sequencer.
 
-       :param qfm: file manager that tracks temporary files
+       :param tfm: file manager that tracks temporary files
        :param config: configuration dictionary
        :param args: parsed arguments
     """
@@ -75,10 +75,10 @@ class QEMUExecuter:
     }
     """Shortcut names for QEMU log sources."""
 
-    def __init__(self, qfm: QEMUFileManager, config: dict[str, any],
+    def __init__(self, tfm: FileManager, config: dict[str, any],
                  args: Namespace):
         self._log = getLogger('pyot.exec')
-        self._qfm = qfm
+        self._tfm = tfm
         self._config = config
         self._args = args
         self._argdict: dict[str, Any] = {}
@@ -163,7 +163,7 @@ class QEMUExecuter:
                                tpos, tcount)
                 vcplogfile = None
                 try:
-                    self._qfm.define_transient({
+                    self._tfm.define_transient({
                         'UTPATH': test,
                         'UTDIR': normpath(dirname(test)),
                         'UTFILE': basename(test),
@@ -199,9 +199,9 @@ class QEMUExecuter:
                     err = str(exc)
                 finally:
                     self._discard_vcp_log(vcplogfile)
-                    self._qfm.cleanup_transient()
-                    if not self._qfm.keep_temporary:
-                        self._qfm.delete_default_dir(test_name)
+                    self._tfm.cleanup_transient()
+                    if not self._tfm.keep_temporary:
+                        self._tfm.delete_default_dir(test_name)
                     flush_memory_loggers(['pyot', 'pyot.vcp', 'pyot.ctx',
                                           'pyot.file'], LOG_INFO)
                 results[tret] += 1
@@ -262,12 +262,6 @@ class QEMUExecuter:
         return args.__dict__.get(name)
 
     @staticmethod
-    def flatten(lst: list) -> list:
-        """Flatten a list.
-        """
-        return [item for sublist in lst for item in sublist]
-
-    @staticmethod
     def abspath(path: str) -> str:
         """Build absolute path"""
         if isabs(path):
@@ -275,10 +269,10 @@ class QEMUExecuter:
         return normpath(joinpath(getcwd(), path))
 
     def _cleanup_temp_files(self, storage: dict[str, set[str]]) -> None:
-        if self._qfm.keep_temporary:
+        if self._tfm.keep_temporary:
             return
         for kind, files in storage.items():
-            delete_file = getattr(self._qfm, f'delete_{kind}_image')
+            delete_file = getattr(self._tfm, f'delete_{kind}_image')
             for filename in files:
                 delete_file(filename)
 
@@ -311,7 +305,7 @@ class QEMUExecuter:
                     # special marker to disable a specific ROM
                     rom_count += 1
                     continue
-                rom_path = self._qfm.interpolate(rom)
+                rom_path = self._tfm.interpolate(rom)
                 if not isfile(rom_path):
                     raise ValueError(f'Unable to find ROM file {rom_path}')
                 rom_ids = []
@@ -438,7 +432,7 @@ class QEMUExecuter:
         if args.otp:
             if not isfile(args.otp):
                 raise ValueError(f'No such OTP file: {args.otp}')
-            otp_file = self._qfm.create_otp_image(args.otp)
+            otp_file = self._tfm.create_otp_image(args.otp)
             temp_files['otp'].add(otp_file)
             qemu_args.extend(('-drive',
                               f'if=pflash,file={otp_file},format=raw'))
@@ -467,7 +461,7 @@ class QEMUExecuter:
                 raise ValueError(f'No such bootloader file: {args.boot}')
             if args.embedded_flash is not None:
                 no_flash_header = args.no_flash_header
-                flash_file = self._qfm.create_eflash_image(xexec, args.boot,
+                flash_file = self._tfm.create_eflash_image(xexec, args.boot,
                                                            no_flash_header)
                 temp_files['flash'].add(flash_file)
                 qemu_args.extend(('-drive', f'if=mtd,id=eflash,'
@@ -525,9 +519,9 @@ class QEMUExecuter:
 
     def _build_test_list(self, alphasort: bool = True) -> list[str]:
         pathnames = set()
-        testdir = normpath(self._qfm.interpolate(self._config.get('testdir',
+        testdir = normpath(self._tfm.interpolate(self._config.get('testdir',
                                                                   curdir)))
-        self._qfm.define({'testdir': testdir})
+        self._tfm.define({'testdir': testdir})
         cfilters = self._args.filter or []
         pfilters = [f for f in cfilters if not f.startswith('!')]
         if not pfilters:
@@ -545,7 +539,7 @@ class QEMUExecuter:
             if sep in vname:
                 raise ValueError(f"Virtual test name cannot contain directory "
                                  f"specifier: '{vname}'")
-            rpath = normpath(self._qfm.interpolate(vpath))
+            rpath = normpath(self._tfm.interpolate(vpath))
             if not isfile(rpath):
                 raise ValueError(f"Invalid virtual test '{vname}': "
                                  f"missing file '{rpath}'")
@@ -603,7 +597,7 @@ class QEMUExecuter:
         incf_filters = self._build_config_list(config_entry)
         if incf_filters:
             for incf in incf_filters:
-                incf = normpath(self._qfm.interpolate(incf))
+                incf = normpath(self._tfm.interpolate(incf))
                 if not isfile(incf):
                     raise ValueError(f'Invalid test file: "{incf}"')
                 self._log.debug('Loading test list from %s', incf)
@@ -613,7 +607,7 @@ class QEMUExecuter:
                         testfile = re.sub('#.*$', '', testfile).strip()
                         if not testfile:
                             continue
-                        testfile = self._qfm.interpolate(testfile)
+                        testfile = self._tfm.interpolate(testfile)
                         if not testfile.startswith(sep):
                             testfile = joinpath(incf_dir, testfile)
                         yield normpath(testfile)
@@ -674,10 +668,10 @@ class QEMUExecuter:
             opts = kwargs.get('opts')
             if opts and not isinstance(opts, list):
                 raise ValueError('fInvalid QEMU options for {test_name}')
-            opts = self.flatten([opt.split(' ') for opt in opts])
-            opts = [self._qfm.interpolate(opt) for opt in opts]
-            opts = self.flatten([opt.split(' ') for opt in opts])
-            opts = [self._qfm.interpolate_dirs(opt, test_name) for opt in opts]
+            opts = flatten([opt.split(' ') for opt in opts])
+            opts = [self._tfm.interpolate(opt) for opt in opts]
+            opts = flatten([opt.split(' ') for opt in opts])
+            opts = [self._tfm.interpolate_dirs(opt, test_name) for opt in opts]
         timeout = float(kwargs.get('timeout', DEFAULT_TIMEOUT))
         tmfactor = float(kwargs.get('timeout_factor', DEFAULT_TIMEOUT_FACTOR))
         itimeout = int(timeout * tmfactor)
@@ -692,7 +686,7 @@ class QEMUExecuter:
                 raise ValueError(f'Unsupported expect: {texpect}') from exc
         return Namespace(**kwargs), opts or [], itimeout, texp
 
-    def _build_test_context(self, test_name: str) -> QEMUContext:
+    def _build_test_context(self, test_name: str) -> ExecContext:
         context = defaultdict(list)
         tests_cfg = self._config.get('tests', {})
         test_cfg = tests_cfg.get(test_name, {})
@@ -711,23 +705,22 @@ class QEMUExecuter:
                                          f'"{ctx_name}" for test {test_name}')
                     cmd = re.sub(r'[\n\r]', ' ', cmd.strip())
                     cmd = re.sub(r'\s{2,}', ' ', cmd)
-                    cmd = self._qfm.interpolate(cmd)
-                    cmd = self._qfm.interpolate_dirs(cmd, test_name)
+                    cmd = self._tfm.interpolate(cmd)
+                    cmd = self._tfm.interpolate_dirs(cmd, test_name)
                     context[ctx_name].append(cmd)
             env = test_cfg.get('env')
             if env:
                 if not isinstance(env, dict):
                     raise ValueError('Invalid context environment')
-                test_env = {k: self._qfm.interpolate(v) for k, v in env.items()}
-        return QEMUContext(test_name, self._qfm, self._qemu_cmd, dict(context),
-                           test_env)
+                test_env = {k: self._tfm.interpolate(v) for k, v in env.items()}
+        return ExecContext(test_name, self._qemu_cmd, dict(context), test_env)
 
     def _log_vcp_streams(self, exec_info: EasyDict[str, Any]) -> str:
         logfile = exec_info.get('logfile', None)
         if not logfile:
             return None
         assert exec_info.test_name
-        logfile = self._qfm.interpolate_dirs(logfile, exec_info.test_name)
+        logfile = self._tfm.interpolate_dirs(logfile, exec_info.test_name)
         vcplog = getLogger('pyot.vcp')
         logfh = FileHandler(logfile, 'w')
         # log everything

--- a/python/qemu/ot/pyot/executer.py
+++ b/python/qemu/ot/pyot/executer.py
@@ -28,7 +28,7 @@ from ot.util.misc import EasyDict, alphanum_key, flatten
 from . import DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_FACTOR
 from .context import ExecContext
 from .filemgr import FileManager
-from .util import TestCandidate, TestResult
+from .util import ExecTime, TestCandidate, TestResult
 from .wrapper import Wrapper
 
 
@@ -213,7 +213,7 @@ class Executer:
                     if debug:
                         print(format_exc(chain=False), file=sys.stderr)
                     tret = 99
-                    xtime = 0.0
+                    xtime = ExecTime(0.0)
                     err = str(exc)
                 finally:
                     self._discard_vcp_log(vcplogfile)

--- a/python/qemu/ot/pyot/executer.py
+++ b/python/qemu/ot/pyot/executer.py
@@ -23,12 +23,12 @@ import sys
 
 from ot.util.file import guess_file_type
 from ot.util.log import flush_memory_loggers
-from ot.util.misc import EasyDict, flatten
+from ot.util.misc import EasyDict, alphanum_key, flatten
 
 from . import DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_FACTOR
 from .context import ExecContext
 from .filemgr import FileManager
-from .util import TestResult
+from .util import TestCandidate, TestResult
 from .wrapper import Wrapper
 
 
@@ -41,6 +41,7 @@ class Executer:
     """
 
     RESULT_MAP = {
+        -1: 'SKIPPED',
         0: 'PASS',
         1: 'ERROR',
         6: 'ABORT',
@@ -114,11 +115,13 @@ class Executer:
         """Enumerate tests to execute.
         """
         self._argdict = dict(self._args.__dict__)
-        for tst in sorted(self._build_test_list()):
+        for candidate in sorted(self._build_test_list()):
+            tst, reason = candidate.name, candidate.reason
             tpath = self._virtual_tests.get(tst)
             ttype = guess_file_type(tpath or tst)
             rpath = f' [{basename(tpath)}]' if tpath else ''
-            yield f'{basename(tst)} ({ttype}){rpath}'
+            discarded = f' {{discarded: {reason}}}' if reason else ''
+            yield f'{basename(tst)} ({ttype}){rpath}{discarded}'
 
     def run(self, debug: bool, allow_no_test: bool) -> int:
         """Execute all requested tests.
@@ -162,18 +165,28 @@ class Executer:
                 return 1
             targs = None
             temp_files = {}
-            for tpos, test in enumerate(tests, start=1):
-                test_name = None
-                self._log.info('[TEST %s] (%d/%d)', self.get_test_radix(test),
-                               tpos, tcount)
+            for tpos, tcand in enumerate(tests, start=1):
+                test, reason = tcand.name, tcand.reason
+                test_name = self.get_test_radix(test)
                 vcplogfile = None
+                if reason:
+                    tret = -1
+                    sret = self.RESULT_MAP[tret]
+                    if csv:
+                        self._log.info('[TEST %s] (%d/%d) skipped',
+                                       test_name, tpos, tcount)
+                        csv.writerow(TestResult(test_name, sret, '',
+                                                '', reason.title()))
+                        cfp.flush()
+                        results[tret] += 1
+                    continue
                 try:
                     self._tfm.define_transient({
                         'UTPATH': test,
                         'UTDIR': normpath(dirname(test)),
                         'UTFILE': basename(test),
                     })
-                    test_name = self.get_test_radix(test)
+                    self._log.info('[TEST %s] (%d/%d)', test_name, tpos, tcount)
                     exec_info = self._build_test_command(test)
                     exec_info.test_name = test_name
                     vcplogfile = self._log_vcp_streams(exec_info)
@@ -234,7 +247,7 @@ class Executer:
                            self.RESULT_MAP.get(kind, kind),
                            results[kind])
         # sort by the largest occurence, discarding success
-        errors = sorted((x for x in results.items() if x[0]),
+        errors = sorted((x for x in results.items() if x[0] > 0),
                         key=lambda x: -x[1])
         # overall return code is the most common error, or success otherwise
         ret = errors[0][0] if errors else 0
@@ -297,7 +310,7 @@ class Executer:
         exec_info.expect_result = texp
         return exec_info
 
-    def _build_test_list(self, alphasort: bool = True) -> list[str]:
+    def _build_test_list(self) -> list[TestCandidate]:
         pathnames = set()
         testdir = normpath(self._tfm.interpolate(self._config.get('testdir',
                                                                   curdir)))
@@ -328,7 +341,10 @@ class Executer:
         inc_filters = self._build_config_list('include')
         if inc_filters:
             self._log.debug('Searching for tests from %s dir', testdir)
-            for path_filter in filter(None, inc_filters):
+            for candidate in inc_filters:
+                path_filter = candidate.name
+                if not path_filter:
+                    continue
                 if testdir:
                     path_filter = joinpath(testdir, path_filter)
                 paths = set(glob(path_filter, recursive=True))
@@ -354,29 +370,44 @@ class Executer:
             return []
         roms = self._argdict.get('rom', [])
         pathnames -= {normpath(rom) for rom in roms}
-        xtfilters = [f[1:].strip() for f in cfilters if f.startswith('!')]
+
+        xtfilters = [TestCandidate(f[1:].strip(), 'CMDLINE')
+                     for f in cfilters if f.startswith('!')]
         exc_filters = self._build_config_list('exclude')
         xtfilters.extend(exc_filters)
+        discarded: set[TestCandidate] = set()
         if xtfilters:
-            for path_filter in filter(None, xtfilters):
+            for candidate in xtfilters:
+                path_filter, reason = candidate.name, candidate.reason
+                if not path_filter:
+                    continue
                 if testdir:
                     path_filter = joinpath(testdir, path_filter)
                 paths = set(glob(path_filter, recursive=True))
+                if reason:
+                    discarded.update(TestCandidate(t, reason)
+                                     for t in pathnames & paths)
                 pathnames -= paths
                 vdiscards: set[str] = set()
                 for vpath in vtests:
                     if fnmatchcase(vpath, basename(path_filter)):
                         vdiscards.add(vpath)
+                if reason:
+                    discarded.update(TestCandidate(t, reason)
+                                     for t in pathnames & vdiscards)
                 pathnames -= vdiscards
-        pathnames -= set(self._enumerate_from('exclude_from'))
-        if alphasort:
-            return sorted(pathnames, key=basename)
-        return list(pathnames)
+        ftfilters = set(self._enumerate_from('exclude_from'))
+        pathnames -= ftfilters
+        candidates = set(TestCandidate(t) for t in pathnames)
+        candidates.update(discarded)
+        return sorted(candidates,
+                      key=lambda tc: alphanum_key(basename(tc.name)))
 
     def _enumerate_from(self, config_entry: str) -> Iterator[str]:
         incf_filters = self._build_config_list(config_entry)
         if incf_filters:
-            for incf in incf_filters:
+            for candidate in incf_filters:
+                incf = candidate.name
                 incf = normpath(self._tfm.interpolate(incf))
                 if not isfile(incf):
                     raise ValueError(f'Invalid test file: "{incf}"')
@@ -392,8 +423,8 @@ class Executer:
                             testfile = joinpath(incf_dir, testfile)
                         yield normpath(testfile)
 
-    def _build_config_list(self, config_entry: str) -> list:
-        cfglist = []
+    def _build_config_list(self, config_entry: str) -> list[TestCandidate]:
+        cfglist: list[str] = []
         items = self._config.get(config_entry)
         if not items:
             return cfglist
@@ -402,7 +433,7 @@ class Executer:
                              f'"{config_entry}" is not a list')
         for item in items:
             if isinstance(item, str):
-                cfglist.append(item)
+                cfglist.append(TestCandidate(item))
                 continue
             if isinstance(item, dict):
                 for dname, dval in item.items():
@@ -417,7 +448,7 @@ class Executer:
                     if isinstance(dval, list):
                         for sitem in dval:
                             if isinstance(sitem, str):
-                                cfglist.append(sitem)
+                                cfglist.append(TestCandidate(sitem, dname))
         return cfglist
 
     def _build_test_args(self, test_name: str) \

--- a/python/qemu/ot/pyot/executer.py
+++ b/python/qemu/ot/pyot/executer.py
@@ -49,6 +49,23 @@ class Executer:
         Wrapper.GUEST_ERROR_OFFSET + 1: 'FAIL',
         98: 'UNEXP_SUCCESS',
         99: 'CONTEXT',
+        # convention: exit code in [100..115] range report uncaught exceptions
+        100: 'INST_ADDR_MISALIGN',
+        101: 'INST_ACCESS_FAULT',
+        102: 'INST_ILLEGAL',
+        103: 'BREAKPOINT',
+        104: 'LOAD_ADDR_ALIGN',
+        105: 'LOAD_ACCESS_FAULT',
+        106: 'STORE_ADDR_ALIGN',
+        107: 'STORE_ACCESS_FAULT',
+        108: 'ECALL_U_MODE',
+        109: 'ECALL_S_MODE',
+        110: 'ECALL_H_MODE',
+        111: 'ECALL_M_MODE',
+        112: 'INST_PAGE_FAULT',
+        113: 'LOAD_PAGE_FAULT',
+        115: 'STORE_PAGE_FAULT',
+        # end of RISC-V exception converted to exit code
         124: 'TIMEOUT',
         125: 'DEADLOCK',
         126: 'CONTEXT',
@@ -62,18 +79,6 @@ class Executer:
 
     DEFAULT_SERIAL_PORT = 'serial0'
     """Default VCP name."""
-
-    LOG_SHORTCUTS = {
-        'A': 'in_asm',
-        'E': 'exec',
-        'G': 'guest_errors',
-        'H': 'help',
-        'I': 'int',
-        'M': 'mmu',
-        'R': 'cpu_reset',
-        'U': 'unimp',
-    }
-    """Shortcut names for QEMU log sources."""
 
     def __init__(self, tfm: FileManager, config: dict[str, any],
                  args: Namespace):

--- a/python/qemu/ot/pyot/filemgr.py
+++ b/python/qemu/ot/pyot/filemgr.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-"""File manager for QEMU unit test sequencer.
+"""File manager for OpenTitan unit test sequencer.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """
@@ -21,13 +21,11 @@ from ot.util.elf import ElfBlob
 from ot.util.file import guess_file_type
 
 
-class QEMUFileManager:
+class FileManager:
     """Simple file manager to generate and track temporary files.
 
        :param keep_temp: do not automatically discard generated files on exit
     """
-
-    DEFAULT_OTP_ECC_BITS = 6
 
     def __init__(self, keep_temp: bool = False):
         self._log = getLogger('pyot.file')

--- a/python/qemu/ot/pyot/qemu/__init__.py
+++ b/python/qemu/ot/pyot/qemu/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""QEMU tools to execute OpenTitan tests.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""

--- a/python/qemu/ot/pyot/qemu/executer.py
+++ b/python/qemu/ot/pyot/qemu/executer.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2023-2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""QEMU test executer for OpenTitan unit test sequencer.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+from argparse import Namespace
+from collections import defaultdict
+from os.path import isfile
+from typing import Any, Optional
+
+import re
+
+from ot.util.file import guess_file_type
+from ot.util.misc import EasyDict
+
+from ..executer import Executer
+
+
+class QEMUExecuter(Executer):
+    """Test execution engine using a QEMU virtual machine
+    """
+
+    def _build_fw_args(self, args: Namespace) \
+            -> tuple[str, Optional[str], list[str], Optional[str]]:
+        rom_exec = bool(args.rom_exec)
+        roms = args.rom or []
+        # rom can be specified as a string or a list of strings
+        if isinstance(roms, str):
+            roms = [roms]
+        multi_rom = (len(roms) + int(rom_exec)) > 1
+        # generate pre-application ROM option
+        fw_args: list[str] = []
+        machine = args.machine
+        variant = args.variant
+        chiplet_count = 1
+        if variant:
+            machine = f'{machine},variant={variant}'
+            try:
+                chiplet_count = sum(int(x)
+                                    for x in re.split(r'[A-Za-z]', variant)
+                                    if x)
+            except ValueError:
+                self._log.warning('Unknown variant syntax %s', variant)
+        rom_counts: list[int] = [0]
+        for chip_id in range(chiplet_count):
+            rom_count = 0
+            for rom in roms:
+                if rom in ('-', '_'):
+                    # special marker to disable a specific ROM
+                    rom_count += 1
+                    continue
+                rom_path = self._tfm.interpolate(rom)
+                if not isfile(rom_path):
+                    raise ValueError(f'Unable to find ROM file {rom_path}')
+                rom_ids = []
+                if args.first_soc:
+                    if chiplet_count == 1:
+                        rom_ids.append(f'{args.first_soc}.')
+                    else:
+                        rom_ids.append(f'{args.first_soc}{chip_id}.')
+                rom_ids.append('rom')
+                if multi_rom:
+                    rom_ids.append(f'{rom_count}')
+                rom_id = ''.join(rom_ids)
+                rom_opt = f'ot-rom_img,id={rom_id},file={rom_path}'
+                fw_args.extend(('-object', rom_opt))
+                rom_count += 1
+            rom_counts.append(rom_count)
+        rom_count = max(rom_counts)
+        xtype = None
+        if args.exec:
+            exec_path = self._virtual_tests.get(args.exec)
+            if not exec_path:
+                exec_path = self.abspath(args.exec)
+            xtype = guess_file_type(exec_path)
+            if xtype == 'spiflash':
+                fw_args.extend(('-drive',
+                                f'if=mtd,id=spiflash,bus=0,format=raw,'
+                                f'file={exec_path}'))
+            elif xtype == 'bin':
+                if args.embedded_flash is None:
+                    raise ValueError(f'{xtype} test type not supported without '
+                                     f'embedded-flash option')
+            else:
+                if xtype != 'elf':
+                    raise ValueError(f'No support for test type: '
+                                     f'{xtype.upper()}')
+                if rom_exec:
+                    # generate ROM option(s) for the application itself
+                    for chip in range(chiplet_count):
+                        rom_id_parts = []
+                        if args.first_soc:
+                            if chiplet_count == 1:
+                                rom_id_parts.append(f'{args.first_soc}.')
+                            else:
+                                rom_id_parts.append(f'{args.first_soc}{chip}.')
+                        rom_id_parts.append('rom')
+                        if multi_rom:
+                            rom_id_parts.append(f'{rom_count}')
+                        rom_id = ''.join(rom_id_parts)
+                        rom_opt = f'ot-rom_img,id={rom_id},file={exec_path}'
+                        fw_args.extend(('-object', rom_opt))
+                    rom_count += 1
+                else:
+                    if args.embedded_flash is None:
+                        if not roms:
+                            fw_args.extend(('-kernel', exec_path))
+                        else:
+                            fw_args.extend(('-device',
+                                            f'loader,file={exec_path}'))
+        else:
+            exec_path = None
+        return machine, xtype, fw_args, exec_path
+
+    def _build_log_sources(self, args: Namespace) -> list[str]:
+        if not args.log:
+            return []
+        log_args = []
+        for arg in args.log:
+            if arg.lower() == arg:
+                log_args.append(arg)
+                continue
+            for upch in arg:
+                try:
+                    logname = self.LOG_SHORTCUTS[upch]
+                except KeyError as exc:
+                    raise ValueError(f"Unknown log name '{upch}'") from exc
+                log_args.append(logname)
+        return ['-d', ','.join(log_args)]
+
+    def _build_vcp_args(self, args: Namespace) -> \
+            tuple[list[str], dict[str, tuple[str, int]]]:
+        device = args.device
+        devdesc = device.split(':')
+        host = devdesc[0]
+        try:
+            port = int(devdesc[1])
+            if not 0 < port < 65536:
+                raise ValueError(f'Invalid serial TCP port: {port}')
+        except IndexError as exc:
+            raise ValueError(f'TCP port not specified: {device}') from exc
+        except TypeError as exc:
+            raise ValueError(f'Invalid TCP serial device: {device}') from exc
+        mux = f'mux={"on" if args.muxserial else "off"}'
+        vcps = args.vcp or [self.DEFAULT_SERIAL_PORT]
+        vcp_args = ['-display', 'none']
+        vcp_map = {}
+        for vix, vcp in enumerate(vcps):
+            vcp_map[vcp] = (host, port+vix)
+            vcp_args.extend(('-chardev',
+                             f'socket,id={vcp},host={host},port={port+vix},'
+                             f'{mux},server=on,wait=on'))
+            if vcp == self.DEFAULT_SERIAL_PORT:
+                vcp_args.extend(('-serial', 'chardev:serial0'))
+        return vcp_args, vcp_map
+
+    def _build_command(self, args: Namespace,
+                       opts: Optional[list[str]] = None) -> EasyDict[str, Any]:
+        """Build QEMU command line from argparser values.
+
+           :param args: the parsed arguments
+           :param opts: any QEMU-specific additional options
+           :return: a dictionary defining how to execute the command
+        """
+        if args.qemu is None:
+            raise ValueError('QEMU path is not defined')
+        machine, xtype, fw_args, xexec = self._build_fw_args(args)
+        qemu_args = [args.qemu, '-M', machine]
+        for otcfg in args.otcfg or []:
+            qemu_args.extend(('-readconfig', self.abspath(otcfg)))
+        qemu_args.extend(fw_args)
+        temp_files = defaultdict(set)
+        if all((args.otp, args.otp_raw)):
+            raise ValueError('OTP VMEM and RAW options are mutually exclusive')
+        if args.otp:
+            if not isfile(args.otp):
+                raise ValueError(f'No such OTP file: {args.otp}')
+            otp_file = self._tfm.create_otp_image(args.otp)
+            temp_files['otp'].add(otp_file)
+            qemu_args.extend(('-drive',
+                              f'if=pflash,file={otp_file},format=raw'))
+        elif args.otp_raw:
+            otp_raw_path = self.abspath(args.otp_raw)
+            qemu_args.extend(('-drive',
+                              f'if=pflash,file={otp_raw_path},format=raw'))
+        if args.flash:
+            if xtype == 'spiflash':
+                raise ValueError('Cannot use a flash file with a flash test')
+            if not isfile(args.flash):
+                raise ValueError(f'No such flash file: {args.flash}')
+            if any((args.exec, args.boot)):
+                raise ValueError('Flash file argument is mutually exclusive '
+                                 'with bootloader or rom extension')
+            flash_path = self.abspath(args.flash)
+            if args.embedded_flash is None:
+                raise ValueError('Embedded flash bus not defined')
+            qemu_args.extend(('-drive', f'if=mtd,id=eflash,'
+                                        f'bus={args.embedded_flash},'
+                                        f'file={flash_path},format=raw'))
+        elif any((xexec, args.boot)):
+            if xexec and not isfile(xexec):
+                raise ValueError(f'No such exec file: {xexec}')
+            if args.boot and not isfile(args.boot):
+                raise ValueError(f'No such bootloader file: {args.boot}')
+            if args.embedded_flash is not None:
+                no_flash_header = args.no_flash_header
+                flash_file = self._tfm.create_eflash_image(xexec, args.boot,
+                                                           no_flash_header)
+                temp_files['flash'].add(flash_file)
+                qemu_args.extend(('-drive', f'if=mtd,id=eflash,'
+                                            f'bus={args.embedded_flash},'
+                                            f'file={flash_file},format=raw'))
+        if args.qemu_log:
+            qemu_args.extend(('-D', self.abspath(args.qemu_log)))
+        for trace in args.trace or []:
+            qemu_args.append('-trace')
+            if isfile(trace):
+                qemu_args.append(f'events={self.abspath(trace)}')
+            else:
+                qemu_args.append(trace)
+        qemu_args.extend(self._build_log_sources(args))
+        if args.singlestep:
+            qemu_args.extend(('-accel', 'tcg,one-insn-per-tb=on'))
+        if 'icount' in args:
+            if args.icount is not None:
+                qemu_args.extend(('-icount', f'shift={args.icount}'))
+        try:
+            start_delay = float(getattr(args, 'start_delay') or
+                                self.DEFAULT_START_DELAY)
+        except ValueError as exc:
+            raise ValueError(f'Invalid start up delay {args.start_delay}') \
+                from exc
+        start_delay *= args.timeout_factor
+        trigger = getattr(args, 'trigger', '')
+        validate = getattr(args, 'validate', '')
+        if trigger and validate:
+            raise ValueError(f"{getattr(args, 'exec', '?')}: 'trigger' and "
+                             f"'validate' are mutually exclusive")
+        asan = getattr(args, 'asan', False)
+        logfile = getattr(args, 'log_file', None)
+        vcp_args, vcp_map = self._build_vcp_args(args)
+        qemu_args.extend(vcp_args)
+        qemu_args.extend(args.global_opts or [])
+        if opts:
+            qemu_args.extend((str(o) for o in opts))
+        return EasyDict(command=qemu_args, vcp_map=vcp_map,
+                        tmpfiles=temp_files, start_delay=start_delay,
+                        trigger=trigger, validate=validate, asan=asan,
+                        logfile=logfile)

--- a/python/qemu/ot/pyot/qemu/executer.py
+++ b/python/qemu/ot/pyot/qemu/executer.py
@@ -23,6 +23,18 @@ class QEMUExecuter(Executer):
     """Test execution engine using a QEMU virtual machine
     """
 
+    LOG_SHORTCUTS = {
+        'A': 'in_asm',
+        'E': 'exec',
+        'G': 'guest_errors',
+        'H': 'help',
+        'I': 'int',
+        'M': 'mmu',
+        'R': 'cpu_reset',
+        'U': 'unimp',
+    }
+    """Shortcut names for QEMU log sources."""
+
     def _build_fw_args(self, args: Namespace) \
             -> tuple[str, Optional[str], list[str], Optional[str]]:
         rom_exec = bool(args.rom_exec)

--- a/python/qemu/ot/pyot/qemu/wrapper.py
+++ b/python/qemu/ot/pyot/qemu/wrapper.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023-2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""QEMU executer wrapper for OpentTitan unit test sequencer.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+import re
+
+from ..wrapper import Wrapper
+
+class QEMUWrapper(Wrapper):
+    """Test execution wrapper using a QEMU virtual machine
+    """
+
+    NAME = 'QEMU'
+
+    USELESS_ERR_CRE = re.compile(r'^\*{1,4}$')
+    """Useless error stuff from QEMU."""
+
+    def _discard_log(self, err: bool, line: str):
+        return self.USELESS_ERR_CRE.match(line)
+
+    def _decrease_log(self, err: bool, line: str):
+        return line.find('QEMU waiting for connection') >= 0

--- a/python/qemu/ot/pyot/util.py
+++ b/python/qemu/ot/pyot/util.py
@@ -55,23 +55,32 @@ class ResultFormatter:
             for row in csv:
                 self._results.append(row)
 
-    def show(self, spacing: bool = False) -> None:
+    def show(self, spacing: bool = False, result: Optional[str] = None) -> None:
         """Print a simple formatted ASCII table with loaded CSV results.
 
            :param spacing: add an empty line before and after the table
+           :param result: overall result, if any
         """
         results = [r[:-1] + [shorten(r[-1], width=100)] for r in self._results]
         if not results:
             return
         if spacing:
             print('')
+        # third row is time, always defined as ms, see ExecTime
+        total_time = sum(float(r[2].strip().split(' ')[0])
+                               for r in self._results[1:])
+        tt_str = f'{total_time / 1000:.1f} s'
+        last_row = ['TEST SESSION', result or '?', tt_str]
+        last_row.extend([''] * (len(self._results) - len(last_row)))
+        results.append(last_row)
         widths = [max(len(x) for x in col) for col in zip(*results)]
         self._show_line(widths, '-')
         self._show_row(widths, results[0])
         self._show_line(widths, '=')
-        for row in results[1:]:
+        last_rix = len(self._results) - 2
+        for rix, row in enumerate(results[1:]):
             self._show_row(widths, row)
-            self._show_line(widths, '-')
+            self._show_line(widths, '-' if rix != last_rix else '=')
         if spacing:
             print('')
 

--- a/python/qemu/ot/pyot/util.py
+++ b/python/qemu/ot/pyot/util.py
@@ -22,6 +22,13 @@ class ExecTime(float):
         return f'{self*1000:.0f} ms'
 
 
+class TestCandidate(NamedTuple):
+    """Test candidate.
+    """
+    name: str
+    reason: Optional[str] = None
+
+
 class TestResult(NamedTuple):
     """Test result.
     """

--- a/python/qemu/ot/pyot/util.py
+++ b/python/qemu/ot/pyot/util.py
@@ -39,7 +39,7 @@ class ResultFormatter:
         self._results = []
 
     def load(self, csvpath: str) -> None:
-        """Load a CSV file (generated with QEMUExecuter) and parse it.
+        """Load a CSV file (generated with an Executer) and parse it.
 
            :param csvpath: the path to the CSV file.
         """
@@ -82,12 +82,12 @@ class LogMessageClassifier:
 
        :param classifiers: a map of loglevel, list of RE-compatible strings
                            to match messages
-       :param qemux: the QEMU executable name, to filter out useless messages
+       :param app_exec: the executable name, to filter out useless messages
     """
 
     def __init__(self, classifiers: Optional[dict[str, list[str]]] = None,
-                 qemux: Optional[str] = None):
-        self._qemux = qemux
+                 app_exec: Optional[str] = None):
+        self._app_exec = app_exec
         if classifiers is None:
             classifiers = {}
         self._regexes: dict[int, re.Pattern] = {}
@@ -120,7 +120,7 @@ class LogMessageClassifier:
            :param default: defaut log level in no classification is found
            :return: the logger log level to use
         """
-        if self._qemux and line.startswith(self._qemux):
+        if self._app_exec and line.startswith(self._app_exec):
             # discard QEMU internal messages that cannot be disable from the VM
             if line.find("QEMU waiting") > 0:
                 return logging.NOTSET

--- a/python/qemu/ot/pyot/util.py
+++ b/python/qemu/ot/pyot/util.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-"""Utilities for QEMU unit test sequencer.
+"""Utilities for OpenTitan unit test sequencer.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """

--- a/python/qemu/ot/pyot/worker.py
+++ b/python/qemu/ot/pyot/worker.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-"""Test executer for QEMU unit test sequencer.
+"""Test executer for OpenTitan unit test sequencer.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """
@@ -17,9 +17,9 @@ from typing import Optional
 from .util import LogMessageClassifier
 
 
-class QEMUContextWorker:
+class ContextWorker:
 
-    """Background task for QEMU context.
+    """Background task for test executer context.
     """
 
     def __init__(self, cmd: str, env: dict[str, str],

--- a/python/qemu/ot/pyot/worker.py
+++ b/python/qemu/ot/pyot/worker.py
@@ -82,8 +82,8 @@ class ContextWorker:
                      errors='ignore', text=True)
         Thread(target=self._logger, args=(proc, True), daemon=True).start()
         Thread(target=self._logger, args=(proc, False), daemon=True).start()
-        qemu_exec = f'{basename(self._cmd[0])}: '
-        classifier = LogMessageClassifier(qemux=qemu_exec)
+        host_app_exec = f'{basename(self._cmd[0])}: '
+        classifier = LogMessageClassifier(app_exec=host_app_exec)
         while self._resume:
             while self._log_q:
                 err, qline = self._log_q.popleft()

--- a/python/qemu/ot/pyot/wrapper.py
+++ b/python/qemu/ot/pyot/wrapper.py
@@ -30,8 +30,8 @@ from .util import ExecTime, LogMessageClassifier
 class QEMUWrapper:
     """A small engine to run tests with QEMU.
 
-       :param tcpdev: a host, port pair that defines how to access the TCP
-                      Virtual Com Port of QEMU first UART
+       :param log_classifiers: a map of loglevel, list of RE-compatible strings
+                               to match messages
        :param debug: whether running in debug mode
     """
     # pylint: disable=too-few-public-methods
@@ -81,7 +81,7 @@ class QEMUWrapper:
                 - expect_result, the expected outcome of QEMU (exit code). Some
                            tests may expect that QEMU terminates with a non-zero
                            exit code
-                - context, an option QEMUContextWorker instance, to execute
+                - context, an option ContextWorker instance, to execute
                            concurrently with the QEMU process. Many tests
                            expect to communicate with the QEMU process.
                 - trigger, a string to match on the QEMU virtual comm port
@@ -138,9 +138,9 @@ class QEMUWrapper:
             log.debug('Executing QEMU as %s', ' '.join(tdef.command))
             env = dict(environ)
             if tdef.asan:
-                # note cannot use a QEMUFileManager temp file here, as the full
+                # note cannot use a FileManager temp file here, as the full
                 # pathname is built by the ASAN tool once QEMU has started.
-                # store this temporary file in the QEMUFileManager-managed
+                # store this temporary file in the FileManager-managed
                 # work directory
                 asan_prefix = joinpath(workdir, self.ASAN_LOGFILE_PREFIX)
                 env['ASAN_OPTIONS'] = f'log_path={asan_prefix}'

--- a/python/qemu/ot/pyot/wrapper.py
+++ b/python/qemu/ot/pyot/wrapper.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-"""QEMU wrapper for QEMU unit test sequencer.
+"""Host executer wrapper for OpentTitan unit test sequencer.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """
@@ -27,8 +27,8 @@ from ot.util.misc import EasyDict
 from .util import ExecTime, LogMessageClassifier
 
 
-class QEMUWrapper:
-    """A small engine to run tests with QEMU.
+class Wrapper:
+    """A small engine to run OpenTitan tests.
 
        :param log_classifiers: a map of loglevel, list of RE-compatible strings
                                to match messages
@@ -41,16 +41,13 @@ class QEMUWrapper:
 
        The return code of the script is the position plus the GUEST_ERROR_OFFSET
        in the above RE group when matched, except first item which is always 0.
-       This offset is used to differentiate from QEMU own return codes. QEMU may
-       return negative values, which are the negative value of POSIX signals,
-       such as SIGABRT.
+       This offset is used to differentiate from host app own return codes.
+       Host app may return negative values, which are the negative value of
+       POSIX signals, such as SIGABRT.
     """
 
     ANSI_CRE = re.compile(rb'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
     """ANSI escape sequences."""
-
-    USELESS_ERR_CRE = re.compile(r'^\*{1,4}$')
-    """Useless error stuff from QEMU."""
 
     GUEST_ERROR_OFFSET = 40
     """Offset for guest errors. Should be larger than the host max signal value.
@@ -62,41 +59,46 @@ class QEMUWrapper:
     ASAN_LOGFILE_PREFIX = 'asan.log'
     """Address sanitizer log prefix."""
 
+    NAME = 'generic'
+    """Wrapper name."""
+
     def __init__(self, log_classifiers: dict[str, list[str]], debug: bool):
         self._log_classifiers = log_classifiers
         self._debug = debug
         self._log = logging.getLogger('pyot')
-        self._qlog = logging.getLogger('pyot.qemu')
+        self._wlog = logging.getLogger(f'pyot.{self.NAME.lower()}')
 
     def run(self, tdef: EasyDict[str, Any]) -> tuple[int, ExecTime, str]:
-        """Execute the specified QEMU command, aborting execution if QEMU does
-           not exit after the specified timeout.
+        """Execute the specified host app command, aborting execution if the
+           host app does not exit after the specified timeout.
 
            :param tdef: test definition and parameters
-                - command, a list of strings defining the QEMU command to
+                - command, a list of strings defining the host app command to
                            execute with all its options
-                - vcp_map: how to connect to QEMU virtual communication ports
+                - vcp_map: how to connect to host app virtual communication
+                           ports
                 - timeout, the allowed time for the command to execute,
                            specified as a real number
-                - expect_result, the expected outcome of QEMU (exit code). Some
-                           tests may expect that QEMU terminates with a non-zero
-                           exit code
+                - expect_result, the expected outcome of the host app, i.e. its
+                           exit code. Some tests may expect that host app
+                           terminates with a non-zero exit code
                 - context, an option ContextWorker instance, to execute
-                           concurrently with the QEMU process. Many tests
-                           expect to communicate with the QEMU process.
-                - trigger, a string to match on the QEMU virtual comm port
+                           concurrently with the host app process. Many tests
+                           expect to communicate with the host app process.
+                - trigger, a string to match on the host app virtual comm port
                            output to trigger the context execution. It may be
                            defined as a regular expression.
-                - validate, a string to match on the QEMU virtual comm port
+                - validate, a string to match on the host app virtual comm port
                            output to early exit. It may be defined as a regular
                            expression.
                 - start_delay, the delay to wait before starting the execution
-                           of the context once QEMU command has been started.
+                           of the context once the host app command has been
+                           started.
                 - asan, whether to redirect and post-process AddressSanitizer
                            output log
            :return: a 3-uple of exit code, execution time, and last guest error
         """
-        # stdout and stderr belongs to QEMU VM
+        # stdout and stderr belongs to host app
         # OT's UART0 is redirected to a TCP stream that can be accessed through
         # self._device. The VM pauses till the TCP socket is connected
         xre = re.compile(self.EXIT_ON)
@@ -130,16 +132,16 @@ class QEMUWrapper:
         vcp_ctxs: dict[int, list[str, socket, bytearray, logging.Logger]] = {}
         asan_file = None
         log_q = deque()
-        qemu_exec = f'{basename(tdef.command[0])}: '
+        host_app_exec = f'{basename(tdef.command[0])}: '
         classifier = LogMessageClassifier(classifiers=self._log_classifiers,
-                                          qemux=qemu_exec)
+                                          app_exec=host_app_exec)
         try:
             workdir = dirname(tdef.command[0])
-            log.debug('Executing QEMU as %s', ' '.join(tdef.command))
+            log.debug('Executing %s as %s', self.NAME, ' '.join(tdef.command))
             env = dict(environ)
             if tdef.asan:
                 # note cannot use a FileManager temp file here, as the full
-                # pathname is built by the ASAN tool once QEMU has started.
+                # pathname is built by the ASAN tool once host app has started.
                 # store this temporary file in the FileManager-managed
                 # work directory
                 asan_prefix = joinpath(workdir, self.ASAN_LOGFILE_PREFIX)
@@ -156,28 +158,30 @@ class QEMUWrapper:
                 pass
             else:
                 ret = proc.returncode
-                log.fatal('QEMU bailed out: %d for "%s"', ret, tdef.test_name)
+                log.fatal('%s bailed out: %d for "%s"',
+                          self.NAME, ret, tdef.test_name)
                 raise OSError()
-            log.debug('Execute QEMU for %.0f secs', tdef.timeout)
+            log.debug('Execute %s for %.0f secs', self.NAME, tdef.timeout)
             if asan_prefix:
                 asan_file = f'{asan_prefix}.{proc.pid}'
             # unfortunately, subprocess's stdout calls are blocking, so the
-            # only way to get near real-time output from QEMU is to use a
-            # dedicated thread that may block whenever no output is available
+            # only way to get near real-time output from the host app is to use
+            # a dedicated thread that may block whenever no output is available
             # from the VM. This thread reads and pushes back lines to a local
             # queue, which is popped and logged to the local logger on each
             # loop. Note that Popen's communicate() also relies on threads to
             # perform stdout/stderr read out.
-            Thread(target=self._qemu_logger, name='qemu_out_logger',
+            logname = self.NAME.lower()
+            Thread(target=self._log_worker, name=f'{logname}_out_logger',
                    args=(proc, log_q, True), daemon=True).start()
-            Thread(target=self._qemu_logger, name='qemu_err_logger',
+            Thread(target=self._log_worker, name=f'{logname}_err_logger',
                    args=(proc, log_q, False), daemon=True).start()
             poller = spoll()
             connect_map = vcp_map.copy()
             timeout = now() + tdef.start_delay
-            # ensure that QEMU starts and give some time for it to set up
+            # ensure that host app starts and give some time for it to set up
             # when multiple VCPs are set to 'wait', one VCP can be connected at
-            # a time, i.e. QEMU does not open all connections at once.
+            # a time, i.e. host app does not open all connections at once.
             vcp_lognames = []
             vcplogname = 'pyot.vcp'
             while connect_map:
@@ -186,7 +190,8 @@ class QEMUWrapper:
                                       for d, r in connect_map.items())
                     if proc.poll():
                         raise OSError(proc.returncode)
-                    raise TimeoutError(f'Cannot connect to QEMU VCPs: {minfo}')
+                    raise TimeoutError(f'Cannot connect to {self.NAME} '
+                                       f'VCPs: {minfo}')
                 connected = []
                 for vcpid, (host, port) in connect_map.items():
                     try:
@@ -206,8 +211,8 @@ class QEMUWrapper:
                     except ConnectionRefusedError:
                         continue
                     except OSError as exc:
-                        log.error('Cannot setup QEMU VCP connection %s: %s',
-                                  vcpid, exc)
+                        log.error('Cannot setup {%s} VCP connection %s: %s',
+                                  self.NAME, vcpid, exc)
                         print(format_exc(chain=False), file=sys.stderr)
                         raise
                 # removal from dictionary cannot be done while iterating it
@@ -250,8 +255,8 @@ class QEMUWrapper:
                             logfn = getattr(log, 'critical')
                         else:
                             logfn = getattr(log, 'warning')
-                        logfn('Abnormal QEMU termination: %d for "%s"',
-                              ret, tdef.test_name)
+                        logfn('Abnormal %s termination: %d for "%s"',
+                              self.NAME, ret, tdef.test_name)
                     break
                 for vfd, event in poller.poll(0.01):
                     if event in (POLLERR, POLLHUP):
@@ -316,7 +321,7 @@ class QEMUWrapper:
         except (OSError, ValueError) as exc:
             if ret is None:
                 ret = proc.returncode if proc.poll() is not None else 125
-                log.fatal('Unable to execute QEMU: %s', exc)
+                log.fatal('Unable to execute %s: %s', self.NAME, exc)
         finally:
             if xend is None:
                 xend = now()
@@ -331,18 +336,18 @@ class QEMUWrapper:
                     xend = now()
                 proc.terminate()
                 try:
-                    # leave 1 second for QEMU to cleanly complete...
+                    # leave 1 second for host app to cleanly complete...
                     proc.wait(1.0)
                 except TimeoutExpired:
                     # otherwise kill it
-                    log.error('Force-killing QEMU')
+                    log.error('Force-killing %s', self.NAME)
                     proc.kill()
                 if ret is None:
                     ret = proc.returncode
                 # retrieve the remaining log messages
-                stdlog = self._qlog.info if ret else self._qlog.debug
+                stdlog = self._wlog.info if ret else self._wlog.debug
                 for msg, logger in zip(proc.communicate(timeout=1.1),
-                                       (stdlog, self._qlog.error)):
+                                       (stdlog, self._wlog.error)):
                     for line in msg.split('\n'):
                         line = line.strip()
                         if line:
@@ -350,22 +355,24 @@ class QEMUWrapper:
             if asan_file:
                 self._post_process_asan(asan_file)
         xtime = ExecTime(xend-xstart) if xstart and xend else 0.0
-        qemu_cmd_lead = f'{basename(tdef.command[0])}: '
-        if last_error.startswith(qemu_cmd_lead):
-            last_error = last_error[len(qemu_cmd_lead):]
+        app_cmd_lead = f'{basename(tdef.command[0])}: '
+        if last_error.startswith(app_cmd_lead):
+            last_error = last_error[len(app_cmd_lead):]
         return abs(ret) or 0, xtime, last_error
 
     @classmethod
     def classify_log(cls, line: str, default: int = logging.ERROR,
-                     qemux: Optional[str] = None) -> int:
+                     app_exec: Optional[str] = None) -> int:
         """Classify log level of a line depending on its content.
 
            :param line: line to classify
            :param default: defaut log level in no classification is found
+           :param app_exec: host application basename
            :return: the logger log level to use
         """
-        if qemux and line.startswith(qemux):
-            # discard QEMU internal messages that cannot be disable from the VM
+        if app_exec and line.startswith(app_exec):
+            # discard host app internal messages that cannot be disabled from
+            # the VM
             return logging.NOTSET
         if (line.find('info: ') >= 0 or
             line.startswith('INFO ') or
@@ -395,25 +402,32 @@ class QEMUWrapper:
         for color, logname in enumerate(sorted(lognames)):
             clr_fmt.add_logger_colors(f'{vcplogname}.{logname}', color)
 
+    def _discard_log(self, err: bool, line: str):
+        # pylint: disable=unused-argument
+        return False
+
+    def _decrease_log(self, err: bool, line: str):
+        # pylint: disable=unused-argument
+        return False
+
     def _process_log_queue(self, log_q, classifier) -> Optional[str]:
         first_err = None
         while log_q:
             err, qline = log_q.popleft()
             if err:
-                if self.USELESS_ERR_CRE.match(qline):
+                if self._discard_log(err, qline):
                     continue
                 level = classifier.classify(qline, logging.ERROR)
-                if level == logging.INFO and \
-                   qline.find('QEMU waiting for connection') >= 0:
+                if level == logging.INFO and self._decrease_log(err, qline):
                     level = logging.DEBUG
                 if level >= logging.ERROR and not first_err:
                     first_err = qline
             else:
                 level = logging.INFO
-            self._qlog.log(level, qline)
+            self._wlog.log(level, qline)
         return first_err
 
-    def _qemu_logger(self, proc: Popen, queue: deque, err: bool):
+    def _log_worker(self, proc: Popen, queue: deque, err: bool):
         # worker thread, blocking on VM stdout/stderr
         stream = proc.stderr if err else proc.stdout
         while proc.poll() is None:
@@ -467,4 +481,4 @@ class QEMUWrapper:
                 alog.error(aline.rstrip())
             unlink(asan_file)
         except (OSError, ValueError) as exc:
-            self._qlog.error('Cannot process ASAN file: %s', exc)
+            self._wlog.error('Cannot process ASAN file: %s', exc)

--- a/python/qemu/ot/util/argparse.py
+++ b/python/qemu/ot/util/argparse.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024-2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""ArgumentParser extension.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+# pylint: disable=unused-import
+# ruff: noqa: F401
+from argparse import ArgumentParser as _ArgumentParser, FileType
+from sys import stderr
+
+
+class ArgumentParser(_ArgumentParser):
+    """Report usage error first, before printing out the usage. This enables
+       catching the first line as the main error message.
+    """
+
+    def error(self, message):
+        print(f'{self.prog}: error: {message}\n', file=stderr)
+        self.print_usage(stderr)
+        self.exit(2)

--- a/python/qemu/ot/util/eval.py
+++ b/python/qemu/ot/util/eval.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""Safe expression evaluation.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+from typing import Any
+
+import ast
+import operator
+
+
+def safe_eval(value: str, parameters: dict[str, int]) -> int:
+    """Evaluate a basic arithmetic expression using known parameters.
+
+        This is much safer than default Python's eval/expr functions, which
+        could execute any untrusted code.
+
+        Here, only known variables are replaced and basic arithmetic
+        operations are allowed.
+
+        :param value: the value to evaluate
+        :param parameters: a map a key-val named integer values
+        :return: the evaluated integer
+        :raise ValueError: for any unsupported syntax.
+    """
+    def _eval(node: ast.AST) -> Any:
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+
+        # Numeric literal (Python 3.8+: ast.Constant)
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, (int, float)):
+                return node.value
+            raise ValueError('Unsupported constant')
+
+        # Variables/names
+        if isinstance(node, ast.Name):
+            if node.id in parameters:
+                return parameters[node.id]
+            raise ValueError(f'Unknown parameter: {node.id}')
+
+        # Binary operations
+        if isinstance(node, ast.BinOp):
+            op_type = type(node.op)
+            oper = {
+                ast.Add: operator.add,
+                ast.Sub: operator.sub,
+                ast.Mult: operator.mul,
+                ast.Div: operator.truediv,
+            }.get(op_type)
+            if not oper:
+                raise ValueError(f'Cannot evaluate: {op_type.__name__}')
+            left = _eval(node.left)
+            right = _eval(node.right)
+            return oper(left, right)
+
+        raise ValueError(f'Unsupported expression: {type(node).__name__}')
+
+    return _eval(ast.parse(value, mode='eval'))

--- a/python/qemu/ot/util/misc.py
+++ b/python/qemu/ot/util/misc.py
@@ -103,6 +103,11 @@ class EasyDict(dict):
         yield from sorted(items)
 
 
+def flatten(lst: list) -> list:
+    """Flatten a list."""
+    return [item for sublist in lst for item in sublist]
+
+
 def group(lst, count):
     """Group a list into consecutive count-tuples. Incomplete tuples are
     discarded.

--- a/python/qemu/ot/util/misc.py
+++ b/python/qemu/ot/util/misc.py
@@ -33,11 +33,14 @@ class HexInt(int):
         return f'0x{self:x}'
 
     @staticmethod
-    def parse(val: Optional[str], base: Optional[int] = None) \
+    def parse(val: Optional[Union[str, int]], base: Optional[int] = None,
+              accept_int: bool = False) \
             -> Optional['HexInt']:
         """Simple helper to support hexadecimal integer in argument parser."""
         if val is None:
             return None
+        if accept_int and isinstance(val, int):
+            return HexInt(val)
         if base is not None:
             return HexInt(int(val, base))
         return HexInt(int(val, val.startswith('0x') and 16 or 10))

--- a/python/qemu/ot/util/misc.py
+++ b/python/qemu/ot/util/misc.py
@@ -150,6 +150,14 @@ def camel_to_snake_case(camel: str) -> str:
     return re.sub(pattern, '_', camel).lower()
 
 
+def camel_to_snake_uppercase(name: str) -> str:
+    """Extended version of camel_to_snake_case to convert device/parameter
+       names.
+    """
+    pattern = r'(?<=[\d])(?=[A-Z]{2,})'
+    return re.sub(pattern, '_', camel_to_snake_case(name).upper())
+
+
 def to_bool(value, permissive=True, prohibit_int=False):
     """Parse a string and convert it into a boolean value if possible.
 

--- a/python/qemu/ot/util/misc.py
+++ b/python/qemu/ot/util/misc.py
@@ -192,3 +192,11 @@ def to_bool(value, permissive=True, prohibit_int=False):
     if permissive or (value.lower() in _FALSE_BOOLEANS):
         return False
     raise ValueError(f"Invalid boolean value: '{value}")
+
+def alphanum_key(text: str) -> list[Union[int, str]]:
+    """Alphanumerical sorting key.
+
+       :param text: the text to generate a sorting key from
+       :return: a list of alternating str and integer values
+    """
+    return [int(t) if t.isdigit() else t for t in re.split(r'(\d+)', text)]

--- a/scripts/opentitan/autoreg.py
+++ b/scripts/opentitan/autoreg.py
@@ -1,0 +1,965 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""QEMU OT tool to generate register definition for OT device.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+from argparse import ArgumentParser, FileType
+from enum import StrEnum, auto
+from io import StringIO
+from logging import getLogger
+from os.path import dirname, join as joinpath, normpath
+from time import localtime
+from traceback import format_exception
+from textwrap import dedent, indent
+from typing import Any, NamedTuple, Optional, TextIO, Union
+
+import sys
+
+QEMU_PYPATH = joinpath(dirname(dirname(dirname(normpath(__file__)))),
+                       'python', 'qemu')
+sys.path.append(QEMU_PYPATH)
+
+# ruff: noqa: E402
+from ot.util.eval import safe_eval
+from ot.util.log import configure_loggers
+from ot.util.misc import (HexInt, camel_to_snake_case, camel_to_snake_uppercase,
+                          classproperty)
+
+try:
+    _HJSON_ERROR = None
+    from hjson import load as hjload
+except ImportError as hjson_exc:
+    _HJSON_ERROR = str(hjson_exc)
+
+
+class QEMUAccess(StrEnum):
+    """Type of access to a register or a field."""
+    UNDEF = auto()
+    RO = auto()
+    RW = auto()
+    WO = auto()
+    RC = auto()
+    RW0C = auto()
+    RW1C = auto()
+    RW1S = auto()
+    R0W1C = auto()
+    URO = auto()  # "unused read/only"
+
+
+class QEMUField(NamedTuple):
+    """A register field."""
+
+    name: str
+    desc: Optional[str]
+    offset: int
+    width: int
+    access: QEMUAccess
+    reset: int
+
+
+class QEMURegister(NamedTuple):
+    """A register."""
+
+    name: str
+    desc: Optional[str]
+    address: int
+    access: QEMUAccess
+    fields: list[QEMUField]
+    reset: Optional[int]
+    shared_fields: bool = False
+
+
+class QEMUAutoReg:
+    """QEMU register definition generator.
+
+       :param devname: the name of the generated QEMU device
+       :param ignore_prefix: an optional prefix to discard useless register
+                             definitions. Registers and fields starting with
+                             this prefix are ignored.
+       :param resets: a list of reset functions to generate, if any.
+    """
+
+    RESETS = ['enter', 'hold', 'exit']
+
+    def __init__(self, devname: str, ignore_prefix: Optional[str] = None,
+                 resets: Optional[list[str]] = None):
+        self._log = getLogger('autoreg')
+        self._devname = devname
+        self._ignore_prefix = ignore_prefix
+        self._resets = resets or []
+        self._parameters: dict[str, Union[int, bool]] = {}
+        self._regwidth = 0
+        self._registers: list[QEMURegister] = []
+        self._copyright = '@todo Add copyright attributions'
+
+    @classproperty
+    def generators(cls):
+        """Provide a list of supported generators."""
+        # pylint: disable=no-self-argument
+        actions: list[str] = []
+        for item in cls.__dict__:
+            if not item.startswith('generate_'):
+                continue
+            actions.append(item[len('generate_'):])
+        actions.sort()
+        return actions
+
+    @classmethod
+    def redent(cls, text: str, spc: int = 0, strip_end: bool = False) -> str:
+        """Utility function to re-indent code string.
+
+           :param text: the text to re-indent
+           :param spc: the number of leading empty space chars to prefix lines
+           :param strip_end: whether to strip trailing whitespace and newline
+        """
+        text = dedent(text.lstrip('\n'))
+        text = indent(text, ' ' * spc)
+        if strip_end:
+            text = text.rstrip(' ').rstrip('\n')
+        return text
+
+    def load(self, hfp: TextIO) -> None:
+        """Load a register map definition from an OT HJSON file."""
+        hjson = hjload(hfp, object_pairs_hook=dict)
+        # heuristics
+        # registers -seem- to either be a list of registers, or a map of buses
+        # which contain the list of registers; need to check if some bus name
+        # is defined for the registers that need to be parsed
+        bus_if = None
+        for bus in hjson.get('bus_interfaces', []):
+            if bus.get('protocol') != 'tlul':
+                continue
+            if bus.get('direction') != 'device':
+                continue
+            bus_if = bus.get('name')
+            break
+        self._parameters.update(self._parse_parameters(hjson.get('param_list',
+                                                       [])))
+        self._regwidth = int(hjson.get('regwidth', 32))
+        addr_inc = self._regwidth // 8
+        address = 0
+        registers: list[QEMURegister] = []
+        registers.extend(self._parse_interrupts(hjson, address, addr_inc))
+        address = len(registers) * addr_inc
+        registers.extend(self._parse_alerts(hjson, address))
+        address = len(registers) * addr_inc
+        regnames: set[str] = set()
+        regdefs = hjson['registers']
+        if bus_if:
+            self._log.info("Using registers from bus '%s'", bus_if)
+            regdefs = regdefs[bus_if]
+        for item in regdefs:
+            if 'skipto' in item:
+                address = HexInt.parse(item['skipto'])
+                continue
+            if 'multireg' in item:
+                regs = self._parse_registers(address, item['multireg'])
+                for reg in regs:
+                    if reg.name in regnames:
+                        raise ValueError(f'Register {reg.name} redefined')
+                    regnames.add(reg.name)
+                registers.extend(regs)
+                address += addr_inc * len(regs)
+                continue
+            reg = self._parse_register(address, item)
+            if reg:
+                if reg.name in regnames:
+                    prefix = reg.name.split('_')
+                    if prefix in ('INTR', 'ALERT'):
+                        # Comportable registers may already be defined, discard
+                        continue
+                    raise ValueError(f'Register {reg.name} redefined')
+                regnames.add(reg.name)
+                registers.append(reg)
+                address += addr_inc
+        registers.sort(key=lambda r: r.address)
+        self._registers = registers
+
+    @property
+    def copyright(self) -> str:
+        """Return current copyright string.
+        """
+        return self._copyright
+
+    @copyright.setter
+    def copyright(self, copyright_str: str) -> None:
+        """Set copyright string.
+        """
+        self._copyright = copyright_str
+
+    def generate_all(self, tfp: TextIO) -> None:
+        """Generate a QEMU device template file based on the register map.
+
+           :param tfp: output file stream
+        """
+        for gen in 'header register mask regname struct io device'.split():
+            getattr(self, f'generate_{gen}')(tfp)
+
+    def generate_header(self, tfp: TextIO) -> None:
+        """Generate the template for the header of a device driver.
+
+           :param tfp: output file stream
+        """
+        self._generate_header(tfp)
+
+    def generate_struct(self, tfp: TextIO) -> None:
+        """Generate the template for the device state and class stucts.
+
+           :param tfp: output file stream
+        """
+        self._generate_struct(tfp)
+
+    def generate_register(self, tfp: TextIO) -> None:
+        """Generate the register map.
+
+           :param tfp: output file stream
+        """
+        max_addr = max(reg.address for reg in self._registers)
+        nibcount = (max_addr.bit_length() + 3) // 4
+        print('/* clang-format off */', file=tfp)
+        for reg in self._registers:
+            self._generate_register(reg, nibcount, tfp)
+        print('/* clang-format on */\n', file=tfp)
+
+    def generate_param(self, tfp: TextIO) -> None:
+        """Generate the parameter constants.
+
+           :param tfp: output file stream
+        """
+        self._generate_parameters(tfp)
+
+    def generate_reset(self, tfp: TextIO) -> None:
+        """Generate one or more reset functions, based on the selected reset
+           list defined at instantiation time.
+
+           :param tfp: output file stream
+        """
+        nibcount = self._regwidth // 4
+        for reg in self._registers:
+            self._generate_reg_reset(reg, nibcount, tfp)
+
+    def generate_mask(self, tfp: TextIO) -> None:
+        """Generate the write mask associated with the register map.
+
+           :param tfp: output file stream
+        """
+        for reg in self._registers:
+            self._generate_mask(reg, tfp)
+
+    def generate_io(self, tfp: TextIO) -> None:
+        """Generate the template for the MMIO read and write functions.
+
+           :param tfp: output file stream
+        """
+        self._generate_io(self._registers, False, tfp)
+        self._generate_io(self._registers, True, tfp)
+
+    def generate_regname(self, tfp: TextIO) -> None:
+        """Generate the array of register names.
+
+           :param tfp: output file stream
+        """
+        self._generate_reg_wrappers(self._registers, tfp)
+        self._generate_regname_array(self._registers, tfp)
+
+    def generate_device(self, tfp: TextIO) -> None:
+        """Generate the template for the device initializationfunctions.
+
+           :param tfp: output file stream
+        """
+        self._generate_mr_ops(tfp)
+        self._generate_props(tfp)
+        for reset_type in self._resets:
+            self._generate_reset(tfp, reset_type)
+        self._generate_realize(tfp)
+        self._generate_init(tfp)
+        self._generate_class_init(tfp)
+        self._generate_type(tfp)
+
+    def _parse_interrupts(self, hjson:dict[str, Any], address: int,
+                          addr_inc: int) -> list[QEMURegister]:
+        fields: list[QEMUField] = []
+        if hjson.get('no_auto_intr_regs', False):
+            self._log.info('Comportable interrupt generation disabled')
+            return []
+        for fpos, item in enumerate(hjson.get('interrupt_list', [])):
+            access = 'ro' if item.get('type') == 'status' else 'rw1c'
+            fieldargs = [item['name'].upper(), item['desc'], fpos, 1,
+                         QEMUAccess(access), 0]
+            fields.append(QEMUField(*fieldargs))
+        if not fields:
+            return []
+        registers: list[QEMURegister] = []
+        access = self._build_reg_access(fields)
+        regargs = ['INTR_STATE', 'Interrupt state', address, access, fields, 0,
+                   True]
+        registers.append(QEMURegister(*regargs))
+        address += addr_inc
+        ro_acc = QEMUAccess('ro')
+        regargs = ['INTR_ENABLE', 'Interrupt enable', address, ro_acc, [], 0]
+        registers.append(QEMURegister(*regargs))
+        address += addr_inc
+        wo_acc = QEMUAccess('wo')
+        regargs = ['INTR_TEST', 'Interrupt test', address, wo_acc, [], 0]
+        registers.append(QEMURegister(*regargs))
+        return registers
+
+    def _parse_alerts(self, hjson:dict[str, Any], address: int) \
+            -> list[QEMURegister]:
+        fields: list[QEMUField] = []
+        if hjson.get('no_auto_alert_regs', False):
+            self._log.info('Comportable alert generation disabled')
+            return []
+        wo_acc = QEMUAccess('wo')
+        for fpos, item in enumerate(hjson.get('alert_list', [])):
+            fieldargs = [item['name'].upper(), item['desc'], fpos, 1, wo_acc, 0]
+            fields.append(QEMUField(*fieldargs))
+        if not fields:
+            return []
+        regargs = ['ALERT_TEST', 'Alert test', address, wo_acc, fields, 0]
+        return [QEMURegister(*regargs)]
+
+    def _parse_register(self, address: int, reg: dict[str, Any]) \
+            -> Optional[QEMURegister]:
+        name = reg.get('name')
+        if not name:
+            return None
+        if self._ignore_prefix and name.startswith(self._ignore_prefix):
+            return None
+        desc = reg.get('desc')
+        self._log.info('Register: %s', name)
+        fields = self._parse_reg_fields(reg)
+        fields.sort(key=lambda f: f.offset)
+        reset = self._build_reg_reset(fields)
+        access = self._build_reg_access(fields)
+        rname = camel_to_snake_case(name).upper()
+        regargs = [rname, desc, address, access, fields, reset]
+        return QEMURegister(*regargs)
+
+    def _parse_registers(self, address: int, reg: dict[str, Any]) \
+            -> list[QEMURegister]:
+        count = safe_eval(reg['count'], self._parameters)
+        freg = self._parse_register(address, reg)
+        regs = []
+        self._log.info('Generating multireg %s[%d]', freg.name, count)
+        for rpos in range(count):
+            fields = freg.fields if rpos == 0 else []
+            regs.append(
+                freg._replace(name=f'{freg.name}_{rpos}', address=address,
+                              shared_fields=(rpos == 0), fields=fields))
+            address += 4
+        return regs
+
+    def _parse_reg_fields(self, reg: dict[str, Any]) -> list[QEMUField]:
+        fields: list[QEMUField] = []
+        bitfield = 0
+        reg_swaccess = reg.get('swaccess')
+        rname = reg['name']
+        nibcount = self._regwidth // 4
+        for field in reg.get('fields', []):
+            name = field.get('name')
+            if not name:
+                name = rname
+                if fields:
+                    raise ValueError(f'Multiple anonymous bitfields '
+                                     f'for reg {name}')
+            if self._ignore_prefix and name.startswith(self._ignore_prefix):
+                continue
+            desc = field.get('desc')
+            bits = field.get('bits')
+            if ':' in bits:
+                hibit, lobit = (self._parse_bits(x) for x in bits.split(':'))
+                offset = lobit
+                width = hibit-lobit+1
+            else:
+                offset = self._parse_bits(bits)
+                width = 1
+            bitmask = ((1 << width) - 1) << offset
+            if bitmask & bitfield:
+                raise ValueError(f'Bitfield {name} overlap: '
+                                 f'0x{bitfield:0{nibcount}x}, mask '
+                                 f'0x{bitmask:0{nibcount}x}')
+            bitfield |= bitmask
+            try:
+                access = getattr(QEMUAccess,
+                    field.get('swaccess', reg_swaccess).upper())
+            except KeyError as exc:
+                raise RuntimeError(f'Cannot find swaccess for {name}') from exc
+            resval = field.get('resval')
+            reset = HexInt.parse(resval, accept_int=True) \
+                if resval else HexInt(0)
+            fname = camel_to_snake_case(name).upper()
+            fieldargs = [fname, desc, offset, width, access, reset]
+            fields.append(QEMUField(*fieldargs))
+        bitmask = (1 << self._regwidth) - 1
+        if bitfield &~ bitmask:
+            raise ValueError(f'Bitfield {name} out of range: '
+                             f'0x{bitfield:0{nibcount}x}, mask '
+                             f'0x{bitmask:0{nibcount}x}')
+        return fields
+
+    def _parse_bits(self, value: str) -> int:
+        try:
+            # simple integer
+            return int(value)
+        except ValueError:
+            eval_value = safe_eval(value, self._parameters)
+            self._log.info("parametric value '%s' evaluated as '%s'",
+                           value, eval_value)
+            return eval_value
+
+    def _parse_parameters(self, params: list[dict[str, Any]]) \
+            -> dict[str, Union[int, bool]]:
+        parameters: dict[str, Union[int, bool]] = {}
+        converters = {
+            'int': int,
+            'int unsigned': int,
+            'bit': bool
+        }
+        for param in params:
+            name = param.get('name')
+            type_ = param.get('type')
+            value = param.get('default')
+            if not all((name, type_, value is not None)):
+                continue
+            conv = converters.get(type_)
+            if not conv:
+                self._log.warning("Type '%s' for param '%s' is not supported",
+                                  type_, name)
+                continue
+            parameters[name] = conv(value)
+        return parameters
+
+    def _build_reg_reset(self, fields):
+        reset = 0
+        for field in fields:
+            reset |= field.reset << field.offset
+        return reset
+
+    def _build_reg_access(self, fields):
+        access = set(f.access for f in fields)
+        if len(access) == 1:
+            return access.pop()
+        return QEMUAccess.UNDEF
+
+    def _generate_register(self, reg: QEMURegister, nibcount: int,
+                           tfp: TextIO) -> None:
+        print(f'REG{self._regwidth}({reg.name}, 0x{reg.address:0{nibcount}x}u)',
+              file=tfp)
+        if not reg.shared_fields:
+            if len(reg.fields) > 1:
+                for field in reg.fields:
+                    print(f'    FIELD({reg.name}, {field.name}, '
+                          f'{field.offset}u, '
+                          f'{field.width}u)', file=tfp)
+            elif reg.fields:
+                field = reg.fields[0]
+                if reg.name != field.name:
+                    fdname = field.name
+                else:
+                    fdname = field.name.rsplit('_', 1)[-1]
+                print(f'    FIELD({reg.name}, {fdname}, {field.offset}u, '
+                      f'{field.width}u)', file=tfp)
+        else:
+            name = '_'.join(reg.name.rsplit('_', 1)[:-1])
+            if len(reg.fields) > 1:
+                for field in reg.fields:
+                    print(f'    SHARED_FIELD({name}_{field.name}, '
+                          f'{field.offset}u, '
+                          f'{field.width}u)', file=tfp)
+            elif reg.fields:
+                field = reg.fields[0]
+                if name != field.name:
+                    shname = f'{name}_{field.name}'
+                else:
+                    shname = name
+                print(f'    SHARED_FIELD({shname}, '
+                        f'{field.offset}u, '
+                        f'{field.width}u)', file=tfp)
+
+    def _generate_parameters(self, tfp: TextIO) -> None:
+        cat_params: dict[str, dict[str, int]] = {}
+        max_length = 0
+        name_first = ('NUM', )
+        for name, value in self._parameters.items():
+            ucname = camel_to_snake_uppercase(name)
+            parts = ucname.split('_')
+            pre = parts[0]
+            suf = parts[-1]
+            if pre in name_first:
+                cat = pre
+            else:
+                cat = suf
+            if cat not in cat_params:
+                cat_params[cat] = {}
+            cat_params[cat][ucname] = value
+            max_length = max(max_length, len(ucname))
+        for cat in name_first:
+            if cat in cat_params:
+                cat_params[cat] = dict(sorted(cat_params[cat].items()))
+        cat_fmt = {
+            'OFFSET': 'x'
+        }
+        for cat, fmt in cat_fmt.items():
+            if not fmt.endswith('x'):
+                continue
+            if cat not in cat_params:
+                continue
+            maxval = max(cat_params[cat].values())
+            nibble = (maxval.bit_length() + 3) // 4
+            cat_params[cat] = {n: f'0x{v:0{nibble}{fmt}}u'
+                               for n, v in cat_params[cat].items()}
+        for cat in sorted(cat_params):
+            params = cat_params[cat]
+            for name, value in params.items():
+                imod = 'u' if isinstance(value, int) and value >= 0 else ''
+                print(f'#define {name:<{max_length}s} {value}{imod}',
+                      file=tfp)
+            print(file=tfp)
+
+    def _generate_reg_reset(self, reg: QEMURegister, nibcount: int,
+                            tfp: TextIO) -> None:
+        if reg.reset:
+            print(f'    s->regs[R_{reg.name}] = 0x{reg.reset:0{nibcount}x}u;',
+                  file=tfp)
+
+    def _generate_mask(self, reg: QEMURegister, tfp: TextIO) -> None:
+        if len(reg.fields) < 2:
+            return
+        bitmask = sum(((1 << bf.width) - 1) << bf.offset for bf in reg.fields)
+        bitfield = (1 << self._regwidth) - 1
+        if bitfield & ~bitmask == 0:
+            return
+        if not reg.shared_fields:
+            masks: list[str] = [
+                f'R_{reg.name}_{field.name}_MASK' for field in reg.fields
+                if field.access not in (QEMUAccess.RO,)
+            ]
+        else:
+            name = '_'.join(reg.name.rsplit('_', 1)[:-1])
+            masks: list[str] = [
+                f'{name}_{field.name}_MASK' for field in reg.fields
+                if field.access not in (QEMUAccess.RO,)
+            ]
+        if not masks:
+            return
+        maskstr = ' | \\\n     '.join(masks)
+        if not reg.shared_fields:
+            name = reg.name
+        else:
+            name = '_'.join(reg.name.rsplit('_', 1)[:-1])
+        print(f'#define {name}_WMASK \\\n    ({maskstr})\n', file=tfp)
+
+    def _generate_io(self, regs: list[QEMURegister], write: bool,
+                    tfp: TextIO) -> None:
+        nregs = {r.name: r for r in regs}
+        reg_names = set(nregs)
+        reg_defs = {r.name: (sum(((1 << bf.width) - 1) << bf.offset
+                                 for bf in r.fields), r.access) for r in regs}
+        if write:
+            noaccess_types = (QEMUAccess.RO, QEMUAccess.URO)
+        else:
+            noaccess_types = (QEMUAccess.WO, )
+        noaccess_names = {
+            r.name for r in regs if r.access in noaccess_types
+        }
+        rc_names = {
+            r.name for r in regs if r.access == QEMUAccess.RC
+        }
+        reg_names -= noaccess_names
+        if not write and rc_names:
+            reg_names -= rc_names
+        rwidth = self._regwidth
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        vnm = f'val{rwidth}'
+        if write:
+            if rwidth < 64:
+                vcast = f'uint{rwidth}_t val{rwidth} = (uint{rwidth}_t)val64;'
+            else:
+                vcast = ''
+            code = f'''
+            static void {dname}_regs_write(void *opaque, hwaddr addr,
+                                           uint64_t val64, unsigned size)
+            {{
+                {hdname}State *s = opaque;
+                (void)size;
+                {vcast}
+                hwaddr reg = R{rwidth}_OFF(addr);
+
+                uint32_t pc = ibex_get_current_pc();
+                trace_{dname}_io_write(s->ot_id, (uint32_t)addr, REG_NAME(reg),
+                                       val{rwidth}, pc);
+            '''
+        else:
+            if rwidth < 64:
+                vdef = f'uint{rwidth}_t val{rwidth};'
+            else:
+                vdef = ''
+            code = f'''
+            static uint64_t {dname}_regs_read(void *opaque, hwaddr addr,
+                                              unsigned size)
+            {{
+                {hdname}State *s = opaque;
+                (void)size;
+                {vdef}
+
+                hwaddr reg = R{rwidth}_OFF(addr);
+            '''
+        print(self.redent(code), file=tfp)
+        lines = []
+        lines.append('    switch (reg) {')
+        bitfield = (1 << rwidth) - 1
+        if not write:
+            for rname in sorted(reg_names, key=lambda r: nregs[r].address):
+                lines.append(f'case R_{rname}:')
+            lines.append(f'    {vnm} = s->regs[reg];')
+            lines.append('    break;')
+            for rname in sorted(rc_names, key=lambda r: nregs[r].address):
+                lines.append(f'case R_{rname}:')
+            lines.append(f'    {vnm} = s->regs[reg];')
+            lines.append('    s->regs[reg] = 0;')
+            lines.append('    break;')
+        else:
+            for rname in sorted(reg_names, key=lambda r: nregs[r].address):
+                lines.append(f'case R_{rname}:')
+                rbm, racc = reg_defs[rname]
+                if bitfield & rbm:
+                    lines.append(f'    {vnm} &= R_{rname}_WMASK;')
+                if racc in (QEMUAccess.RW1C, QEMUAccess.R0W1C):
+                    lines.append(f'    s->regs[reg] &= ~{vnm}; '
+                                 f'/* {racc.upper()} */')
+                elif racc == QEMUAccess.RW0C:
+                    lines.append(f'    s->regs[reg] &= {vnm}; /* RW0C */')
+                elif racc == QEMUAccess.RW1S:
+                    lines.append(f'    s->regs[reg] |= {vnm}; /* RW1S */')
+                else:
+                    if racc == QEMUAccess.UNDEF:
+                        self._log.warning(
+                            "Register '%s' has multiple access types which is "
+                            "not supported by this script, defaulting to RW.",
+                            rname)
+                        lines.append('    /* @todo handle multiple access type '
+                                     'bitfield */')
+                    lines.append(f'    s->regs[reg] = {vnm};')
+                lines.append('    break;')
+        if noaccess_names:
+            for rname in sorted(noaccess_names, key=lambda r: nregs[r].address):
+                lines.append(f'case R_{rname}:')
+            a = 'R' if write else 'W'
+            lines.append(self.redent(f'''
+            qemu_log_mask(LOG_GUEST_ERROR,
+                          "%s: %s: {a}/O register 0x%02" HWADDR_PRIx " (%s)\\n",
+                          __func__, s->ot_id, addr, REG_NAME(reg));
+            ''', 4, True))
+            lines.append('    break;')
+        lines.append('default:')
+        lines.append('    break;')
+        lines.append('}')
+        print('\n    '.join(lines), file=tfp)
+        if write:
+            code = '};\n'
+        else:
+            rval = '(uint64_t)val{rwidth}' if rwidth < 64 else 'val64'
+            code = f'''
+
+                uint32_t pc = ibex_get_current_pc();
+                trace_{dname}_io_read_out(s->ot_id, (uint32_t)addr, REG_NAME(reg),
+                                        val{rwidth}, pc);
+
+                return {rval};
+            }}
+            '''
+        print(self.redent(code), '', file=tfp)
+
+    def _generate_reg_wrappers(self, regs: list[QEMURegister],
+                               tfp: TextIO) -> None:
+        last = regs[-1].name
+        lines = []
+        lines.append(f'#define R_LAST_REG (R_{last})')
+        lines.append('#define REGS_COUNT (R_LAST_REG + 1u)')
+        lines.append(f'#define REGS_SIZE  (REGS_COUNT * '
+                     f'sizeof(uint{self._regwidth}_t))')
+        lines.append('#define REG_NAME(_reg_) \\')
+        lines.append('    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? '
+                     'REG_NAMES[_reg_] : "?")')
+        lines.append('')
+        print('\n'.join(lines), file=tfp)
+
+    def _generate_regname_array(self, regs: list[QEMURegister],
+                                tfp: TextIO) -> None:
+        lines = []
+        lines.append(
+            '#define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)')
+        lines.append('static const char *REG_NAMES[REGS_COUNT] = {')
+        lines.append('    /* clang-format off */')
+        for reg in regs:
+            lines.append(f'    REG_NAME_ENTRY({reg.name}),')
+        lines.append('    /* clang-format on */')
+        lines.append('};')
+        lines.append('')
+        print('\n'.join(lines), file=tfp)
+
+    def _generate_header(self, tfp: TextIO) -> None:
+        dname = self._devname
+        pname = dname.title().replace('_', ' ')
+        year = localtime().tm_year
+        code = f'''
+        /*
+         * QEMU {pname} device
+         *
+         * Copyright (c) {year} {self.copyright}
+         *
+         * Author(s):
+         *
+         * Permission is hereby granted, free of charge, to any person obtaining a copy
+         * of this software and associated documentation files (the "Software"), to deal
+         * in the Software without restriction, including without limitation the rights
+         * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+         * copies of the Software, and to permit persons to whom the Software is
+         * furnished to do so, subject to the following conditions:
+         *
+         * The above copyright notice and this permission notice shall be included in
+         * all copies or substantial portions of the Software.
+         *
+         * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+         * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+         * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+         * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+         * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+         * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+         * THE SOFTWARE.
+         */
+
+        #include "qemu/osdep.h"
+        #include "qemu/log.h"
+        #include "hw/qdev-properties.h"
+        #include "hw/registerfields.h"
+        #include "hw/sysbus.h"
+        #include "trace.h"
+
+        '''
+        print(self.redent(code), file=tfp)
+
+    def _generate_struct(self, tfp: TextIO) -> None:
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        code = f'''
+        struct {hdname}State {{
+            SysBusDevice parent_obj;
+
+            MemoryRegion mmio;
+
+            char *ot_id;
+        }};
+
+        struct {hdname}Class {{
+            SysBusDeviceClass parent_class;
+            ResettablePhases parent_phases;
+        }};
+
+        '''
+        print(self.redent(code), file=tfp)
+
+    def _generate_mr_ops(self, tfp: TextIO) -> None:
+        dname = self._devname
+        code = f'''
+        static const MemoryRegionOps {dname}_ops = {{
+            .read = &{dname}_io_read,
+            .write = &{dname}_io_write,
+            .endianness = DEVICE_LITTLE_ENDIAN,
+            .impl = {{
+                .min_access_size = 4u,
+                .max_access_size = 4u,
+            }},
+        }};
+        '''
+        print(self.redent(code), file=tfp)
+
+    def _generate_props(self, tfp: TextIO) -> None:
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        code = f'''
+        static Property {dname}_properties[] = {{
+            DEFINE_PROP_STRING(OT_COMMON_DEV_ID, {hdname}State, ot_id),
+            DEFINE_PROP_END_OF_LIST(),
+        }};
+        '''
+        print(self.redent(code), file=tfp)
+
+    def _generate_reset(self, tfp: TextIO, reset_type: str) -> None:
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        uname = dname.upper()
+
+        regio = StringIO()
+        nibcount = self._regwidth // 4
+        for reg in self._registers:
+            self._generate_reg_reset(reg, nibcount, regio)
+        regcode = self.redent(regio.getvalue(), 12, strip_end=True).lstrip()
+
+        code = f'''
+        static void {dname}_reset_{reset_type}(Object *obj, ResetType type)
+        {{
+            {hdname}Class *c = {uname}_GET_CLASS(obj);
+            {hdname}State *s = {uname}(obj);
+
+            if (c->parent_phases.{reset_type}) {{
+                c->parent_phases.{reset_type}(obj, type);
+            }}
+        '''
+        if reset_type == "enter":
+            code += '''
+            memset(s->regs, 0, REG_SIZE);
+
+            '''
+            spacer = ' ' * 8
+            code += f'{regcode}\n{spacer}}}\n'
+        else:
+            code += '}\n'
+        print(self.redent(code), file=tfp)
+
+    def _generate_realize(self, tfp: TextIO) -> None:
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        uname = dname.upper()
+        code = f'''
+        static void {dname}_realize(DeviceState *dev, Error **errp)
+        {{
+            {hdname}State *s = {uname}(dev);
+            (void)errp;
+        }}
+        '''
+        print(self.redent(code), file=tfp)
+
+    def _generate_init(self, tfp: TextIO) -> None:
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        uname = dname.upper()
+        code = f'''
+        static void {dname}_init(Object *obj)
+        {{
+            {hdname}State *s = {uname}(obj);
+
+            memory_region_init_io(&s->mmio, obj, &{hdname}_regs_ops, s,
+                                TYPE_{uname}, REGS_SIZE);
+            sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio);
+
+            s->regs = g_new0(uint{self._regwidth}_t, REGS_COUNT);
+        }}
+        '''
+        print(self.redent(code), file=tfp)
+
+    def _generate_class_init(self, tfp: TextIO) -> None:
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        uname = dname.upper()
+        resets = ', '.join((f'&{dname}_reset_{r}' if r in self._resets
+                            else 'NULL' for r in self.RESETS))
+        code = f'''
+        static void {dname}_class_init(ObjectClass *klass, void *data)
+        {{
+            DeviceClass *dc = DEVICE_CLASS(klass);
+            (void)data;
+
+            dc->realize = &{dname}_realize;
+            device_class_set_props(dc, {dname}_properties);
+            set_bit(DEVICE_CATEGORY_MISC, dc->categories);
+
+            ResettableClass *rc = RESETTABLE_CLASS(klass);
+            {hdname}Class *mc = {uname}_CLASS(klass);
+            resettable_class_set_parent_phases(rc, {resets},
+                                               &mc->parent_phases);
+        }}
+        '''
+        print(self.redent(code), file=tfp)
+
+    def _generate_type(self, tfp: TextIO) -> None:
+        dname = self._devname
+        hdname = dname.title().replace('_', '')
+        uname = dname.upper()
+        code = f'''
+        static const TypeInfo {dname}_info = {{
+            .name = TYPE_{uname},
+            .parent = TYPE_SYS_BUS_DEVICE,
+            .instance_size = sizeof({hdname}State),
+            .instance_init = &{dname}_init,
+            .class_size = sizeof({hdname}Class),
+            .class_init = &{dname}_class_init,
+        }};
+
+        static void {dname}_register_types(void)
+        {{
+            type_register_static(&{dname}_info);
+        }}
+
+        type_init({dname}_register_types);
+        '''
+        print(self.redent(code), file=tfp)
+
+
+def main():
+    """Main routine"""
+    debug = True
+    desc = sys.modules[__name__].__doc__.split('.', 1)[0].strip()
+    argparser = ArgumentParser(description=f'{desc}.')
+    try:
+
+        files = argparser.add_argument_group(title='Files')
+        files.add_argument('-c', '--config', type=FileType('rt'),
+                           metavar='HJSON', required=True,
+                           help='input HJSON definition file')
+        files.add_argument('-o', '--output', type=FileType('wt'),
+                           metavar='FILE',
+                           help='output C file')
+        params = argparser.add_argument_group(title='Parameters')
+        files.add_argument('-C', '--copyright',
+                           help='define copyright string')
+        params.add_argument('-g', '--generate', action='append',
+                           choices=QEMUAutoReg.generators, required=True,
+                           help='what to generate')
+        params.add_argument('-n', '--name', default='foo',
+                           help='device name')
+        params.add_argument('-p', '--ignore', metavar='PREFIX',
+                           help='ignore register/fields starting with prefix')
+        params.add_argument('-r', '--reset', action='append',
+                           choices=QEMUAutoReg.RESETS,
+                           help='generate reset code')
+        extra = argparser.add_argument_group(title='Extras')
+        extra.add_argument('-v', '--verbose', action='count',
+                           help='increase verbosity')
+        extra.add_argument('-d', '--debug', action='store_true',
+                           help='enable debug mode')
+
+        args = argparser.parse_args()
+        debug = args.debug
+
+        if _HJSON_ERROR:
+            argparser.error(f'Missing HJSON module: {_HJSON_ERROR}')
+
+        configure_loggers(args.verbose, 'autoreg')
+
+        areg = QEMUAutoReg(args.name, args.ignore, args.reset)
+        if args.copyright:
+            areg.copyright = args.copyright
+        areg.load(args.config)
+        for gen in args.generate or []:
+            getattr(areg, f'generate_{gen}')(args.output or sys.stdout)
+
+    except (IOError, ValueError, ImportError) as exc:
+        print(f'\nError: {exc}', file=sys.stderr)
+        if debug:
+            print(''.join(format_exception(exc, chain=False)),
+                  file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/opentitan/autotop.py
+++ b/scripts/opentitan/autotop.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+"""QEMU OT tool to generate machine definition for OT device.
+
+   :author: Emmanuel Blot <eblot@rivosinc.com>
+"""
+
+from argparse import ArgumentParser, FileType
+from logging import getLogger
+from os import listdir
+from os.path import (abspath, basename, commonprefix, dirname, isdir, isfile,
+                     join as joinpath)
+from textwrap import dedent, indent
+from traceback import format_exception
+from typing import Any, NamedTuple, TextIO
+import re
+import sys
+
+QEMU_PYPATH = joinpath(dirname(dirname(dirname(abspath(__file__)))),
+                       'python', 'qemu')
+sys.path.append(QEMU_PYPATH)
+
+# ruff: noqa: E402
+from ot.util.log import configure_loggers
+from ot.util.misc import (ArgError, HexInt, camel_to_snake_uppercase,
+                          classproperty)
+
+try:
+    _HJSON_ERROR = None
+    from hjson import load as hjload
+except ImportError as hjson_exc:
+    _HJSON_ERROR = str(hjson_exc)
+
+
+class QEMUDevice(NamedTuple):
+    """A device slot."""
+
+    base: HexInt
+    size: HexInt
+    aspc: str
+
+
+class QEMUSignal(NamedTuple):
+    """Interrupt or Alert"""
+
+    name: str
+    index: int
+
+
+class QEMUAutoTop:
+    """Helper class to generate QEMU machine definition from Top definitions.
+    """
+
+    SV_ENUM_CRE = re.compile(
+        r'(?s)typedef\s+enum\s+([\w\s]*){([^\}]*)}\s+(\w+);')
+    SV_ENUM_ITEM_CRE = re.compile(r'(?s)([\w\d]+)(?:\s+=\s+(\d+))?,')
+    SV_PARAM_CRE = re.compile(r"parameter\sint\sunsigned\s([A-Z0-9_]+)\s"
+                              r"=\s\d+'h([0-9a-fA-F]+);")
+    DEVICE_MAP = {
+        'OTP_MACRO': 'OTP_BACKEND',
+        'RV_CORE_IBEX': 'IBEX_WRAPPER',
+        'RV_PLIC': 'PLIC',
+        'RV_TIMER': 'TIMER',
+    }
+    """RTL-to-QEMU renamed devices."""
+
+    def __init__(self, topname):
+        self._log = getLogger('autotop')
+        self._topname = topname
+        self._ases: list[str] = []
+        self._devices: dict[str, dict[str, QEMUDevice]] = {}
+        self._interrupts: dict[str, list[tuple[str, int]]] = {}
+        self._alerts: dict[str, list[tuple[str, int]]] = {}
+        self._pinmux: dict[str, list[str]] = {}
+        self._mbox_indices: dict[str, int] = {}
+
+    def load(self, ot_dir: str) -> None:
+        """Load configuration files.
+
+           :param: OpenTitan top directory
+        """
+        ot_dir = abspath(ot_dir)
+        top = f'top_{self._topname}'
+        topdir = joinpath(ot_dir, f'hw/{top}')
+        if not isdir(topdir):
+            raise ArgError(f"No such top '{self._topname}'")
+        topcfg = joinpath(topdir, 'data/autogen', f'{top}.gen.hjson')
+        if not isfile(topcfg):
+            raise ArgError(f"No config file for top '{self._topname}'")
+        self._load_devices(topdir)
+        with open(topcfg, 'rt') as hfp:
+            hjson = hjload(hfp, object_pairs_hook=dict)
+        self._load_all_interrupts(hjson)
+        self._load_all_alerts(hjson)
+        self._load_pinmux(hjson)
+
+    @classmethod
+    def redent(cls, text: str, spc: int = 0, strip_end: bool = False) -> str:
+        """Utility function to re-indent code string.
+
+           :param text: the text to re-indent
+           :param spc: the number of leading empty space chars to prefix lines
+           :param strip_end: whether to strip trailing whitespace and newline
+        """
+        text = dedent(text.lstrip('\n'))
+        text = indent(text, ' ' * spc)
+        if strip_end:
+            text = text.rstrip(' ').rstrip('\n')
+        return text
+
+    @classmethod
+    def device_name(cls, name: str, discard_aon: bool = False) -> str:
+        """Generate the devices name.
+
+           :param name: original name
+           :param discard_aon: discard AON qualifier
+        """
+        pname = name.upper()
+        if discard_aon:
+            pname = pname.replace('_AON', '')
+        return cls.DEVICE_MAP.get(pname, pname)
+
+    # pylint: disable=no-self-argument
+    @classproperty
+    def languages(cls) -> list[str]:
+        """Report which language generations are supported.
+        """
+        prefix = 'generate_'
+        return list(sorted(f[len(prefix):]
+                    for f in dir(cls) if f.startswith(prefix)))
+
+    def generate_c(self, prefix: str, tfp: TextIO) -> None:
+        """Generate a QEMU template file or machine definition.
+
+           :param prefix: prefix for C definition
+           :param tfp: output file stream
+        """
+        lprefix = prefix.lower()
+        self._generate_c_dev_enum(prefix, tfp)
+        self._generate_c_pinmux(prefix, tfp)
+        print(f'static const IbexDeviceDef {lprefix}_devices[] = {{', file=tfp)
+        print('/* clang-format off */', file=tfp)
+        for devname in sorted(self._devices, key=self._device_address):
+            self._generate_c_devices(prefix, devname, tfp)
+        print('/* clang-format on */', file=tfp)
+        print('};', file=tfp)
+
+    def generate_rust(self, _: str, tfp: TextIO) -> None:
+        """Generate a Rust template file for machine definition.
+
+           :param tfp: output file stream
+        """
+        self._generate_rust_base_addresses(tfp)
+        self._generate_rust_interrupts(tfp)
+        self._generate_rust_alerts(tfp)
+        self._generate_rust_pinmux(tfp)
+
+    def _load_devices(self, topdir: str) -> None:
+        iptopdir = f'{topdir}/ip'
+        for ipdir in listdir(iptopdir):
+            ippath = joinpath(iptopdir, ipdir)
+            if not isdir(ippath) or not ipdir.startswith('xbar_'):
+                continue
+            gendir = joinpath(ippath, 'data/autogen')
+            if not isdir(gendir):
+                continue
+            for genfile in listdir(gendir):
+                if (not genfile.endswith('.gen.hjson') or
+                    not genfile.startswith('xbar_')):
+                    continue
+                xbarcfg = joinpath(gendir, genfile)
+                if not isfile(xbarcfg):
+                    continue
+                self._load_xbar(xbarcfg)
+
+    def _load_xbar(self, xbarcfg: str) -> None:
+        """Load a Top xbar configuration file.
+
+           :param xbarcfg: path to the HJSON to load
+        """
+        with open(xbarcfg, 'rt') as hfp:
+            hjson = hjload(hfp, object_pairs_hook=dict)
+        self._ases = hjson.get('addr_spaces')
+        if not self._ases:
+            raise ValueError('No address space defined')
+        if len(self._ases) > 1:
+            raise NotImplementedError('Multiple address spaces')
+        aspc = self._ases[0]
+        xbar = basename(xbarcfg).split('.')[0].split('_', 1)[-1]
+        self._log.debug('Address space for %s: %s', xbar, ', '.join(self._ases))
+        for node in hjson.get('nodes', []):
+            if node['type'] != 'device':
+                continue
+            if node['xbar']:
+                continue
+            parts = node['name'].split('.', 1)
+            name = parts[0]
+            subname = parts[1] if len(parts) > 1 else 'regs'
+            if subname in ('core', 'jtag', 'dmi', 'prim', 'cfg'):
+                subname = 'regs'
+            addr_ranges = node.get('addr_range')
+            if not addr_ranges:
+                continue
+            self._log.debug('loading device %s (%s)', name, subname)
+            for addr_range in addr_ranges:
+                base_addrs = addr_range.get('base_addrs', {})
+                if len(base_addrs) != 1:
+                    raise NotImplementedError('Multiple base addresses')
+                addr = HexInt(base_addrs[aspc], 16)
+                size = HexInt(addr_range.get('size_byte', 0), 16)
+                dev = QEMUDevice(addr, size, aspc)
+                uname = self.device_name(name, True)
+                if uname not in self._devices:
+                    self._devices[uname] = {}
+                self._devices[uname][subname] = dev
+
+    def _load_all_interrupts(self, hjson: dict[str, Any]) -> None:
+        interrupts = self._load_interrupts( hjson.get('interrupt', []))
+        irq_num = 0
+        for dev, name in interrupts:
+            if dev not in self._interrupts:
+                self._interrupts[dev] = []
+            irq_num += 1  # IRQ #0 is not an IRQ
+            self._interrupts[dev].append(QEMUSignal(name, irq_num))
+        self._log.info('found %d interrupts', irq_num)
+
+    def _load_interrupts(self, interrupts: dict[str, Any]) \
+            -> list[tuple[str, str]]:
+        int_list: list[tuple[str, str]] = []
+        for interrupt in interrupts:
+            name = interrupt['name'].lower()
+            dev = self.device_name(interrupt['module_name'], True)
+            width = interrupt.get('width', 1)
+            prefix = f'{dev.lower()}_'
+            if name.startswith(prefix):
+                name = name[len(prefix):]
+            if width == 1:
+                int_list.append((dev, name))
+            else:
+                int_list.extend((dev, f'{name}{pos}') for pos in range(width))
+        return int_list
+
+    def _load_all_alerts(self, hjson: dict[str, Any]) -> None:
+        alerts: list[tuple[str, str]] = []
+        alerts.extend(self._load_alerts('', hjson.get('alert', [])))
+        for cat, cat_alerts in hjson.get('incoming_alert', {}).items():
+            alerts.extend(self._load_alerts(f'incoming_{cat}', cat_alerts))
+        alert_num = 0
+        for dev, name in alerts:
+            if dev not in self._alerts:
+                self._alerts[dev] = []
+            self._alerts[dev].append(QEMUSignal(name, alert_num))
+            alert_num += 1
+        self._log.info('found %d alerts', alert_num)
+
+    def _load_alerts(self, cat: str, alerts: dict[str, Any]) \
+            -> None:
+        alert_list: list[tuple[str, str]] = []
+        if cat:
+            cat = f'{cat}_'.upper()
+        for alert in alerts:
+            name = alert['name']
+            dev = self.device_name(alert['module_name'], True)
+            lname = name.lower()
+            prefix = f'{dev.lower()}_'
+            if lname.startswith(prefix):
+                lname = lname[len(prefix):]
+            alert_list.append((f'{cat}{dev}', lname))
+        return alert_list
+
+    def _load_pinmux(self, hjson: dict[str, Any]) -> None:
+        pinmux = hjson.get('pinmux', {})
+        ios = pinmux.get('ios', [])
+        pinmap: dict[str, list[str]] = {
+            'dio': [],
+            'mio_in': [],
+            'mio_out': [],
+            'mio_inout': [],
+        }
+        for ioe in ios:
+            name = ioe['name']
+            cnx = ioe['connection']
+            idx = ioe['idx']
+            type_ = ioe['type']
+            iname = f'{name}{idx}' if idx >= 0 else name
+            if cnx == 'direct':
+                pinmap['dio'].append(iname)
+            elif cnx == 'muxed':
+                if type_ == 'input':
+                    pinmap['mio_in'].append(iname)
+                elif type_ == 'output':
+                    pinmap['mio_out'].append(iname)
+                elif type_ == 'inout':
+                    pinmap['mio_inout'].append(iname)
+                else:
+                    self._log.error('Unknown MIO type %s', type_)
+            elif cnx == 'manual':
+                # not yet implemented
+                self._log.warning('Unmanaged connection type %s', cnx)
+            else:
+                self._log.error('Unknown connection type %s', cnx)
+        self._pinmux = pinmap
+
+    def _device_address(self, dev: str) -> int:
+        try:
+            return self._devices[dev]['regs'].base
+        except KeyError:
+            try:
+                return self._devices[dev]['ctn'].base
+            except KeyError:
+                return -1
+
+    def _get_mbox_index(self, udev: str) -> int:
+        if udev not in self._mbox_indices:
+            self._mbox_indices[udev] = len(self._mbox_indices)
+        return self._mbox_indices[udev]
+
+    def _generate_c_dev_enum(self, prefix: str, tfp: TextIO) -> None:
+        lines = []
+        uprefix = prefix.upper()
+        tprefix = prefix.title().replace('_', '')
+        print(f'enum {tprefix}Device {{', file=tfp)
+        for dev in sorted(self._devices):
+            lines.append(f'{uprefix}_DEV_{dev}')
+        code = self.redent(',\n'.join(lines), 4)
+        print(code, file=tfp)
+        print('}\n', file=tfp)
+
+    def _generate_c_pinmux(self, prefix: str, tfp: TextIO) -> None:
+        tprefix = prefix.title().replace('_', '')
+        for ioname, pinmux in self._pinmux.items():
+            lines = []
+            u_ioname = ioname.upper()
+            uc_ioname = ioname.title().replace('_', '')
+            print(f'enum {tprefix}Pinmux{uc_ioname} {{', file=tfp)
+            max_val = 0
+            for val, ion in enumerate(pinmux):
+                us_ion = camel_to_snake_uppercase(ion)
+                lines.append(f'{u_ioname}_{us_ion}, /* {val} */')
+                max_val = max(val, max_val)
+            lines.append(f'{u_ioname}_COUNT, /* {max_val + 1} */')
+            code = self.redent('\n'.join(lines), 4)
+            print(code, file=tfp)
+            print('}\n', file=tfp)
+
+    def _generate_c_devices(self, prefix: str, dev: str, tfp: TextIO) -> None:
+        lines: list[str] = []
+        uprefix = prefix.upper()
+        irq_defs = self._generate_c_irq_defs(uprefix, dev)
+        alert_defs = self._generate_c_alert_defs(uprefix, dev)
+        mmap_defs = self._generate_c_mmap_defs(dev)
+        if dev not in self._devices:
+            self._log.warning('%s not in devices', dev)
+        lines.append(f'[{uprefix}_DEV_{dev}] = {{')
+        mmo = re.match(r'(MBX(?:_[A-Z]+)?)\d*$', dev)
+        if mmo:
+            # mailboxes are defined with a macro
+            mbxidx = self._get_mbox_index(dev)
+            addr = self._devices[dev]['regs'].base
+            irq = self._interrupts[dev][0]
+            try:
+                alert = self._alerts[dev][0]
+            except KeyError:
+                # temporary
+                alert = QEMUSignal("missing", -1)
+            mbox_map = {'MBX_JTAG' : 'DEBUG'}
+            if mmo.group(1) not in mbox_map:
+                lines.append(f'    {uprefix}_DEV_MBX({mbxidx}, {addr}u, '
+                             f'"ot-mbx.sram", {irq.index}, {alert.index}),')
+            else:
+                mmem = mbox_map[dev]
+                spacer = ' ' * len(f'    {uprefix}_DEV_MBX_DUAL(')
+                lines.append(f'    {uprefix}_DEV_MBX_DUAL({mbxidx}, {addr}u, '
+                             f'"ot-mbx.sram", {irq.index}, {alert.index},')
+                lines.append(f'{spacer}'
+                             f'{mmem}_MEMORY({uprefix}_{mmem}_{dev}_ADDR))')
+        else:
+            devbase = re.sub(r'\d+$', '', dev)
+            lines.append(f'    .type = TYPE_OT_{devbase},')
+            if mmap_defs:
+                lines.append('    .memmap = MEMMAPENTRIES(')
+                lines.append(self.redent(',\n'.join(mmap_defs), 8))
+                lines.append('    ),')
+            if irq_defs or alert_defs:
+                defs = []
+                defs.extend(irq_defs)
+                defs.extend(alert_defs)
+                lines.append('    .gpio = IBEXGPIOCONNDEFS(')
+                lines.append(self.redent(',\n'.join(defs), 8))
+                lines.append('    ),')
+        lines.append('},')
+        code = self.redent('\n'.join(lines), 4)
+        print(code, file=tfp)
+
+    def _generate_c_mmap_defs(self, device: str) -> list[str]:
+        # sorting memory range the weird way (hack ahead)
+        # we want the IBEX bus to be seen first (vs. debug or external buses)
+        # and appear in the logical address order
+        def _sort_mems(dev):
+            bus, addr = dev.base >> 28, dev.base & ~(0xf << 28)
+            if dev.aspc == 'hart':
+                return ('', -bus, addr)
+            return (dev.aspc, -bus, addr)
+
+        mmaps = []
+        for dev in sorted(self._devices.get(device, {}).values(),
+                          key=_sort_mems):
+            width = '08' if dev.aspc == 'hart' else ''
+            mmaps.append(f'{{ .base = 0x{dev.base:{width}x}u }}')
+        return mmaps
+
+    def _generate_c_alert_defs(self, prefix: str, dev: str) -> list[str]:
+        alerts = []
+        for pos, alert in enumerate(self._alerts.get(dev, [])):
+            alerts.append(f'{prefix}_GPIO_ALERT({pos}, {alert.index})')
+        return alerts
+
+    def _generate_c_irq_defs(self, prefix: str, dev: str) -> list[str]:
+        irqs = []
+        for pos, irq in enumerate(self._interrupts.get(dev, [])):
+            irqs.append(f'{prefix}_GPIO_SYSBUS_IRQ({pos}, PLIC, '
+                        f'{irq.index})')
+        return irqs
+
+    def _generate_rust_base_addresses(self, tfp):
+        utop = self._topname.upper()
+        print('pub mod base_addresses {', file=tfp)
+        for dev in sorted(self._devices, key=self._device_address):
+            devices = self._devices[dev]
+            devcount = len(devices)
+            dev = re.sub('^RV_', '', dev)
+            dev = re.sub(f'_{utop}$', '', dev)
+            dev = re.sub(f'^{utop}_', '', dev)
+            for name, slot in devices.items():
+                suffix = ''
+                if devcount > 1:
+                    if name in ('dbg', 'soc'):
+                        continue
+                    mbxmo = re.match(r'^MBX(.*)', dev)
+                    if mbxmo:
+                        dev = f'MBXHOST{mbxmo.group(1)}'
+                        suffix = ''
+                    else:
+                        suffix = {
+                            'regs': '_CTRL',
+                            'mem': '_MEM',
+                            'ram': '_MEM',
+                            'rom': '_MEM',
+                        }.get(name) or f'_{name.upper()}'
+                elif dev.startswith('SOC_PROXY'):
+                    dev = 'CTN'
+                print(f'    pub const {dev}{suffix}: usize = {slot.base:#_x};',
+                      file=tfp)
+        print('}\n', file=tfp)
+
+    def _generate_rust_interrupts(self, tfp):
+        irqs: dict[str, int] = {}
+        if not self._interrupts:
+            return
+        for dev, dev_irqs in self._interrupts.items():
+            for irq in dev_irqs:
+                irqname = irq.name.upper()
+                prefix = commonprefix((irqname, dev))
+                if prefix:
+                    irqname = irqname[len(prefix):].lstrip('_')
+                irqs[f'{dev}_{irqname}'] = irq.index
+        print('pub mod irq_num {', file=tfp)
+        max_val = 0
+        for name, val in sorted(irqs.items(), key=lambda irq: irq[1]):
+            print(f'    pub const {name}: usize = {val};', file=tfp)
+            max_val = max(val, max_val)
+        print(f'    pub const COUNT: usize = {max_val + 1};', file=tfp)
+        print('}\n', file=tfp)
+
+    def _generate_rust_alerts(self, tfp) -> None:
+        alerts: dict[str, int] = {}
+        if not self._alerts:
+            return
+        for dev, dev_alerts in self._alerts.items():
+            for alert in dev_alerts:
+                alerts[f'{dev}_{alert.name.upper()}'] = alert.index
+        print('pub mod alert_num {', file=tfp)
+        max_val = 0
+        for name, val in sorted(alerts.items(), key=lambda alert: alert[1]):
+            print(f'    pub const {name}: usize = {val};', file=tfp)
+            max_val = max(val, max_val)
+        print(f'    pub const COUNT: usize = {max_val};', file=tfp)
+        print('}\n', file=tfp)
+
+    def _generate_rust_pinmux(self, tfp) -> None:
+        for ioname, pinmux in self._pinmux.items():
+            if not pinmux:
+                continue
+            print(f'pub mod pinmux_{ioname} {{', file=tfp)
+            max_val = 0
+            for val, ion in enumerate(pinmux):
+                us_ion = camel_to_snake_uppercase(ion)
+                print(f'    pub const {us_ion}: usize = {val};', file=tfp)
+                max_val = max(val, max_val)
+            print(f'    pub const COUNT: usize = {max_val};', file=tfp)
+            print('}\n', file=tfp)
+
+
+def main():
+    """Main routine."""
+    debug = True
+    desc = sys.modules[__name__].__doc__.split('.', 1)[0].strip()
+    argparser = ArgumentParser(description=f'{desc}.')
+    try:
+        languages = list(QEMUAutoTop.languages)
+        top = argparser.add_argument_group(title='Top')
+        top.add_argument('opentitan', nargs='?', metavar='OTDIR',
+                           help='OpenTitan root directory')
+        top.add_argument('-T', '--top', required=True,
+                           help='OpenTitan top name')
+        files = argparser.add_argument_group(title='Files')
+        files.add_argument('-o', '--output', type=FileType('wt'),
+                           metavar='FILE',
+                           help='output file name')
+        files.add_argument('-p', '--prefix', default='ot_dj_soc',
+                           help='constant prefix (default: ot_dj_soc)')
+        files.add_argument('-l', '--language', choices=languages,
+                           default=languages[0],
+                           help=f'output file language '
+                                f'(default: {languages[0]})')
+        extra = argparser.add_argument_group(title='Extras')
+        extra.add_argument('-v', '--verbose', action='count',
+                           help='increase verbosity')
+        extra.add_argument('-d', '--debug', action='store_true',
+                           help='enable debug mode')
+
+        args = argparser.parse_args()
+        debug = args.debug
+
+        if _HJSON_ERROR:
+            argparser.error(f'Missing HJSON module: {_HJSON_ERROR}')
+
+        configure_loggers(args.verbose, 'autotop')
+
+        ot_dir = args.opentitan
+        if not args.opentitan:
+            argparser.error('OTDIR is required is no top file is specified')
+        if not isdir(ot_dir):
+            argparser.error('Invalid OpenTitan root directory')
+        atop = QEMUAutoTop(args.top)
+        atop.load(ot_dir)
+        getattr(atop, f'generate_{args.language}')(args.prefix,
+                                                   args.output or sys.stdout)
+
+    except ArgError as exc:
+        argparser.error(str(exc))
+    except (IOError, ValueError, ImportError) as exc:
+        print(f'\nError: {exc}', file=sys.stderr)
+        if debug:
+            print(''.join(format_exception(exc, chain=False)),
+                  file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/opentitan/cfggen.py
+++ b/scripts/opentitan/cfggen.py
@@ -12,10 +12,10 @@
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from logging import getLogger
-from os.path import abspath, dirname, isdir, isfile, join as joinpath, normpath
+from os.path import (abspath, basename, dirname, isdir, isfile,
+                     join as joinpath, normpath)
 from traceback import format_exc
 from typing import NamedTuple, Optional, TextIO
-import re
 import sys
 
 QEMU_PYPATH = joinpath(dirname(dirname(dirname(normpath(__file__)))),
@@ -31,10 +31,11 @@ except ImportError as hjson_exc:
         """dummy func if HJSON module is not available"""
         return {}
 
+from ot.lc_ctrl.const import LcCtrlConstants
 from ot.otp.const import OtpConstants
-from ot.otp.lifecycle import OtpLifecycle
+from ot.otp.secret import OtpSecretConstants
 from ot.util.log import configure_loggers
-from ot.util.misc import camel_to_snake_case, to_bool
+from ot.util.misc import ArgError, alphanum_key, to_bool
 
 
 OtParamRegex = str
@@ -87,63 +88,82 @@ class OtClockGroup(NamedTuple):
 
 
 class OtConfiguration:
-    """QEMU configuration file generator."""
+    """QEMU configuration file generator.
+
+       This may seem complicated and duplicated, since it is. This script tries
+       to deal with the many way to define constants that have been used in many
+       implementations of OpenTitan and that have changed over time. YMMV.
+    """
+
+    MODULES = {
+        'rom_ctrl': (True, r'RndCnstScr(.*)'),
+        'otp_ctrl': (False, r'RndCnst(.*)Init'),
+        'lc_ctrl': (False, r'RndCnstLcKeymgrDiv(.*)'),
+        'keymgr':  (False, r'RndCnst((?:.*)Seed)',
+                           # The CDI keymgr seed does not match 'RndCnst.*Seed'
+                           r'RndCnst(Cdi)'),
+        'keymgr_dpe': (False, r'RndCnst((?:.*)Seed)'),
+    }
+    """Secrets to extract from OT modules, defined as regexes where the first
+       capturing group of the first matching string in the module defines the
+       secret name to store.
+    """
+
+    TRANSLATIONS = {
+        'keymgr': {'cdi': 'cdi_seed'}
+    }
+    """Secret name translations from OT definitions to QEMU property names."""
 
     def __init__(self):
         self._log = getLogger('cfggen.cfg')
-        self._lc_states: tuple[str, str] = ('', '')
-        self._lc_transitions: tuple[str, str] = ('', '')
-        self._socdbg: tuple[str, str] = ('', '')
-        self._ownership: tuple[str, str] = ('', '')
-        self._roms: dict[Optional[int], dict[str, str]] = {}
-        self._otp: dict[str, str] = {}
-        self._lc: dict[str, str] = {}
-        self._keymgr: dict[str, str] = {}
-        self._keymgr_name: Optional[str] = None
+        self._otpconst = OtpConstants()
+        self._lcconst = LcCtrlConstants()
+        self._constants: dict[str, dict[Optional[int], dict[str, str]]] = {}
         self._top_clocks: dict[str, OtClock] = {}
         self._sub_clocks: dict[str, OtDerivedClock] = {}
         self._clock_groups: dict[str, OtClockGroup] = {}
         self._mod_clocks: dict[str, list[str]] = {}
         self._top_name: Optional[str] = None
+        self._exclusions: dict[str, set[str]] = {}
 
     @property
     def top_name(self) -> Optional[str]:
         """Return the name of the top as defined in a configuration file."""
         return self._top_name
 
-    def load_top_config(self, toppath: str) -> None:
-        """Load data from HJSON top configuration file."""
+    def load_config(self, toppath: str) -> None:
+        """Load data from HJSON configuration file."""
         assert not _HJSON_ERROR
         with open(toppath, 'rt') as tfp:
             cfg = hjload(tfp, object_pairs_hook=dict)
         self._top_name = cfg.get('name')
+        topbase = basename(toppath)
+
         for module in cfg.get('module') or []:
             modtype = module.get('type')
-            if modtype == 'rom_ctrl':
-                self._load_top_values(module, self._roms, True,
-                                      r'RndCnstScr(.*)')
+            moddefs = self.MODULES.get(modtype)
+            if not moddefs:
                 continue
-            if modtype == 'otp_ctrl':
-                self._load_top_values(module, self._otp, False,
-                                      r'RndCnst(.*)Init')
+            multi, regexes = moddefs[0], moddefs[1:]
+            consts = {}
+            OtpSecretConstants.load_values(module, consts, multi, *regexes)
+            if not consts:
                 continue
-            if modtype == 'lc_ctrl':
-                self._load_top_values(module, self._lc, False,
-                                      r'RndCnstLcKeymgrDiv(.*)')
-                continue
-            if modtype.startswith('keymgr'):
-                self._keymgr_name = modtype
-                self._load_top_values(
-                    module,
-                    self._keymgr,
-                    False,
-                    r"RndCnst((?:.*)Seed)",
-                    # The CDI keymgr seed does not match `RndCnst.*Seed`
-                    r"RndCnst(Cdi)",
-                )
-                if "cdi" in self._keymgr:
-                    self._keymgr["cdi_seed"] = self._keymgr.pop("cdi")
-                continue
+            for cname, tname in self.TRANSLATIONS.get(modtype, {}).items():
+                if cname in consts:
+                    consts[tname] = consts.pop(cname)
+            self._log.debug('Constants for %s loaded from %s', modtype, topbase)
+            exist = modtype in self._constants
+            if multi:
+                if not exist:
+                    self._constants[modtype] = consts
+                else:
+                    self._constants[modtype].update(consts)
+            else:
+                if exist:
+                    raise ValueError(f'Redefinition of {modtype}')
+                self._constants[modtype] = {None: consts}
+
         clocks = cfg.get('clocks', {})
         for clock in clocks.get('srcs', []):
             name = clock['name']
@@ -215,75 +235,105 @@ class OtConfiguration:
             mod_clocks[name] = clocks
         self._mod_clocks = mod_clocks
 
-    def load_lifecycle(self, lcpath: str) -> None:
-        """Load LifeCycle data from RTL file."""
-        lcext = OtpLifecycle()
-        with open(lcpath, 'rt') as lfp:
-            lcext.load(lfp)
-        states = lcext.get_configuration('LC_STATE')
-        if not states:
-            raise ValueError('Cannot obtain LifeCycle states')
-        for raw in {s for s in states if int(s, 16) == 0}:
-            del states[raw]
-        ostates = list(states)
-        self._lc_states = ostates[0], ostates[-1]
-        self._log.info("States first: '%s', last '%s'",
-                       states[self._lc_states[0]], states[self._lc_states[1]])
-        trans = lcext.get_configuration('LC_TRANSITION_CNT')
-        if not trans:
-            raise ValueError('Cannot obtain LifeCycle transitions')
-        for raw in {s for s in trans if int(s, 16) == 0}:
-            del trans[raw]
-        otrans = list(trans)
-        self._lc_transitions = otrans[0], otrans[-1]
-        self._log.info('Transitions first: %d, last %d',
-                       int(trans[self._lc_transitions[0]]),
-                       int(trans[self._lc_transitions[1]]))
-        self._lc.update(lcext.get_tokens(False, False))
-        socdbg = lcext.get_configuration('SOCDBG')
-        if socdbg:
-            for raw in {s for s in socdbg if int(s, 16) == 0}:
-                del socdbg[raw]
-            osoc = list(socdbg)
-            self._socdbg = osoc[0], osoc[-1]
-            self._log.info("Socdbg first: '%s', last '%s'",
-                           socdbg[self._socdbg[0]], socdbg[self._socdbg[1]])
-        ownership = lcext.get_configuration('OWNERSHIP')
-        if ownership:
-            for raw in {s for s in ownership if int(s, 16) == 0}:
-                del ownership[raw]
-            osoc = list(ownership)
-            self._ownership = osoc[0], osoc[-1]
-            self._log.info("Ownership first: '%s', last '%s'",
-                           ownership[self._ownership[0]],
-                           ownership[self._ownership[1]])
+    def load_lifecycle(self, svpath: str) -> None:
+        """Load LifeCycle data from RTL file.
 
-    def load_otp_constants(self, otppath: str) -> None:
-        """Load OTP data from RTL file."""
-        otpconst = OtpConstants()
-        with open(otppath, 'rt') as cfp:
-            otpconst.load(cfp)
+           :param svpath: System Verilog file with OTP constants
+        """
+        with open(svpath, 'rt') as cfp:
+            self._log.debug('Loading LC constants from %s', svpath)
+            self._lcconst.load_sv(cfp)
+
+    def load_otp_constants(self, svpath: str) -> None:
+        """Load OTP data from RTL file.
+
+           :param svpath: System Verilog file with OTP constants
+        """
+        with open(svpath, 'rt') as cfp:
+            self._log.debug('Loading OTP constants from %s', svpath)
+            self._otpconst.load_sv(cfp)
+
+    def load_constants(self, hjpath: Optional[str]) -> None:
+        """Load definitions from HJSON file.
+
+           :param hjpath: HJSON file with constants
+        """
+        if not hjpath:
+            return
+        assert not _HJSON_ERROR
+        self._log.debug('Loading secrets from %s', hjpath)
+        hjbase = basename(hjpath)
+        with open(hjpath, 'rt') as tfp:
+            cfg = hjload(tfp, object_pairs_hook=dict)
+        for module in cfg.get('module') or []:
+            modtype = module.get('type')
+            moddefs = self.MODULES.get(modtype)
+            if not moddefs:
+                continue
+            multi, regexes = moddefs[0], moddefs[1:]
+            consts = {}
+            OtpSecretConstants.load_values(module, consts, multi, *regexes)
+            if not consts:
+                continue
+            for cname, tname in self.TRANSLATIONS.get(modtype, {}).items():
+                if cname in consts:
+                    consts[tname] = consts.pop(cname)
+            self._log.debug('Constants for %s loaded from %s',
+                            modtype, hjbase)
+            exist = modtype in self._constants
+            if multi:
+                if not exist:
+                    self._constants[modtype] = consts
+                else:
+                    self._constants[modtype].update(consts)
+            else:
+                if exist:
+                    raise ValueError(f'Redefinition of {modtype}')
+                self._constants[modtype] = {None: consts}
+        self._otpconst.load_secrets(cfg)
+
+    def prepare(self) -> None:
+        """Prepare generation of data, aggregating several sources.
+        """
         digests = {
             'cnsty_digest': 'digest',
             'flash_data_key': 'flash_data',
             'flash_addr_key': 'flash_addr',
             'sram_data_key': 'sram',
         }
-        avail_digests = otpconst.get_digests()
+        avail_digests = self._otpconst.get_digests()
+        otp_ctrl = self._constants['otp_ctrl'][None]
         for digest, prefix in digests.items():
             if digest not in avail_digests:
                 continue
-            pair = otpconst.get_digest_pair(digest, prefix)
-            self._otp.update(pair)
+            pair = self._otpconst.get_digest_pair(digest, prefix)
+            otp_ctrl.update(pair)
         idx = 0
         while True:
             try:
-                defaults = otpconst.get_partition_inv_defaults(idx)
+                defaults = self._otpconst.get_partition_inv_defaults(idx)
                 if defaults:
-                    self._otp[f'inv_default_part_{idx}'] = defaults
+                    otp_ctrl[f'inv_default_part_{idx}'] = defaults
                 idx += 1
             except ValueError:
                 break
+        lc_ctrl = self._constants['lc_ctrl'][None]
+        lc_ctrl.update(self._lcconst.tokens)
+
+    def exclude(self, exclusions: list[str]) -> None:
+        """Add property exclusions.
+
+           :param exclusions: property defined as <device>.<name_prefix> to
+                              exclude from generation
+        """
+        for exclude in exclusions:
+            try:
+                dev, prop = exclude.split('.')
+            except ValueError as exc:
+                raise ArgError(f'Invalid exclusion format: {exclude}') from exc
+            if dev not in self._exclusions:
+                self._exclusions[dev] = set()
+            self._exclusions[dev].add(prop)
 
     def save(self, variant: str, socid: Optional[str], count: Optional[int],
              ofp: Optional[TextIO]) -> None:
@@ -293,7 +343,7 @@ class OtConfiguration:
         cfg = ConfigParser()
         self._generate_roms(cfg, socid, count or 1)
         self._generate_otp(cfg, variant, socid)
-        self._generate_life_cycle(cfg, socid)
+        self._generate_lc_ctrl(cfg, socid)
         self._generate_key_mgr(cfg, socid)
         self._generate_ast(cfg, variant, socid)
         self._generate_clkmgr(cfg, socid)
@@ -306,43 +356,20 @@ class OtConfiguration:
         for modname, modclocks in sorted(self._mod_clocks.items()):
             print(f'{modname:{mod_max_len}s}', ', '.join(modclocks), file=ofp)
 
-    @classmethod
-    def add_pair(cls, data: dict[str, str], kname: str, value: str) -> None:
+    def add_pair(self, devname: str, data: dict[str, str], kname: str,
+                 value: str) -> None:
         """Helper to create key, value pair entries."""
+        for exc in self._exclusions.get(devname, []):
+            if kname.startswith(exc):
+                self._log.debug('Discarding %s.%s property', devname, kname)
+                return
         if value:
             data[f'  {kname}'] = f'"{value}"'
-
-    def _load_top_values(self, module: dict, odict: dict, multi: bool,
-                         *regexes: tuple[OtParamRegex, ...]) -> None:
-        modname = module.get('name')
-        if not modname:
-            return
-        for params in module.get('param_list', []):
-            if not isinstance(params, dict):
-                continue
-            for regex in regexes:
-                pmo = re.match(regex, params['name'])
-                if not pmo:
-                    continue
-                value = params.get('default')
-                if not value:
-                    continue
-                if value.startswith('0x'):
-                    value = value[2:]
-                kname = camel_to_snake_case(pmo.group(1))
-                if multi:
-                    imo = re.search(r'(\d+)$', modname)
-                    idx = int(imo.group(1)) if imo else None
-                    if idx not in odict:
-                        odict[idx] = {}
-                    odict[idx][kname] = value
-                else:
-                    odict[kname] = value
 
     def _generate_roms(self, cfg: ConfigParser, socid: Optional[str] = None,
                        count: int = 1) -> None:
         for cnt in range(count):
-            for rom, data in self._roms.items():
+            for rom, data in self._constants['rom_ctrl'].items():
                 nameargs = ['ot-rom_ctrl']
                 if socid:
                     if count > 1:
@@ -354,7 +381,7 @@ class OtConfiguration:
                 romname = '.'.join(nameargs)
                 romdata = {}
                 for kname, val in sorted(data.items()):
-                    self.add_pair(romdata, kname, val)
+                    self.add_pair(romname, romdata, kname, val)
                 cfg[f'ot_device "{romname}"'] = romdata
 
     def _generate_otp(self, cfg: ConfigParser, variant: str,
@@ -364,40 +391,46 @@ class OtConfiguration:
             nameargs.append(socid)
         otpname = '.'.join(nameargs)
         otpdata = {}
-        for kname, val in self._otp.items():
-            self.add_pair(otpdata, kname, val)
-        otpdata = dict(sorted(otpdata.items()))
+        otp_ctrl = self._constants['otp_ctrl'][None]
+        for kname, val in otp_ctrl.items():
+            self.add_pair(otpname, otpdata, kname, val)
+
+        otpdata = dict(sorted(otpdata.items(),
+                              key=lambda x: alphanum_key(x[0])))
         cfg[f'ot_device "{otpname}"'] = otpdata
 
-    def _generate_life_cycle(self, cfg: ConfigParser,
-                             socid: Optional[str] = None) -> None:
+    def _generate_lc_ctrl(self, cfg: ConfigParser,
+                          socid: Optional[str] = None) -> None:
         nameargs = ['ot-lc_ctrl']
         if socid:
             nameargs.append(socid)
         lcname = '.'.join(nameargs)
         lcdata = {}
-        self.add_pair(lcdata, 'lc_state_first', self._lc_states[0])
-        self.add_pair(lcdata, 'lc_state_last', self._lc_states[1])
-        self.add_pair(lcdata, 'lc_trscnt_first', self._lc_transitions[0])
-        self.add_pair(lcdata, 'lc_trscnt_last', self._lc_transitions[1])
-        self.add_pair(lcdata, 'ownership_first', self._ownership[0])
-        self.add_pair(lcdata, 'ownership_last', self._ownership[1])
-        self.add_pair(lcdata, 'socdbg_first', self._socdbg[0])
-        self.add_pair(lcdata, 'socdbg_last', self._socdbg[1])
-        for kname, value in self._lc.items():
-            self.add_pair(lcdata, kname, value)
+        for name, states in self._lcconst.states.items():
+            self.add_pair(lcname, lcdata, f'{name}_first', states[0])
+            self.add_pair(lcname, lcdata, f'{name}_last', states[1])
+        lc_ctrl = self._constants['lc_ctrl'][None]
+        for kname, value in lc_ctrl.items():
+            self.add_pair(lcname, lcdata, kname, value)
         lcdata = dict(sorted(lcdata.items()))
         cfg[f'ot_device "{lcname}"'] = lcdata
 
     def _generate_key_mgr(self, cfg: ConfigParser,
                           socid: Optional[str] = None) -> None:
-        nameargs = [f'ot-{self._keymgr_name}']
+        keymgr = None
+        for keymgr_name in ('keymgr', 'keymgr_dpe'):
+            if keymgr_name in self._constants:
+                keymgr = self._constants[keymgr_name][None]
+                break
+        else:
+            return
+        nameargs = [f'ot-{keymgr_name}']
         if socid:
             nameargs.append(socid)
         kmname = '.'.join(nameargs)
         kmdata = {}
-        for kname, value in self._keymgr.items():
-            self.add_pair(kmdata, kname, value)
+        for kname, value in keymgr.items():
+            self.add_pair(kmname, kmdata, kname, value)
             kmdata = dict(sorted(kmdata.items()))
             cfg[f'ot_device "{kmname}"'] = kmdata
 
@@ -406,15 +439,15 @@ class OtConfiguration:
         nameargs = [f'ot-ast-{variant}']
         if socid:
             nameargs.append(socid)
-        clkname = '.'.join(nameargs)
-        clkdata = {}
+        astname = '.'.join(nameargs)
+        astdata = {}
         topclockstr = ','.join(f'{c.name}:{c.frequency}'
                                for c in self._top_clocks.values())
         aonclockstr = ','.join(c.name for c in self._top_clocks.values()
                                if c.aon)
-        self.add_pair(clkdata, 'topclocks', topclockstr)
-        self.add_pair(clkdata, 'aonclocks', aonclockstr)
-        cfg[f'ot_device "{clkname}"'] = clkdata
+        self.add_pair(astname, astdata, 'topclocks', topclockstr)
+        self.add_pair(astname, astdata, 'aonclocks', aonclockstr)
+        cfg[f'ot_device "{astname}"'] = astdata
 
     def _generate_clkmgr(self, cfg: ConfigParser,
                          socid: Optional[str] = None) -> None:
@@ -436,28 +469,28 @@ class OtConfiguration:
             clkrefname = None
             clfrefval = None
         topclockdefs = []
-        for clkname, clkval in self._top_clocks.items():
+        for ckname, ckval in self._top_clocks.items():
             if clfrefval:
-                clkratio = clkval.frequency // clfrefval.frequency
+                clkratio = ckval.frequency // clfrefval.frequency
             else:
                 clkratio = 1
-            topclockdefs.append(f'{clkname}:{clkratio}')
+            topclockdefs.append(f'{ckname}:{clkratio}')
         topclockstr = ','.join(topclockdefs)
         subclockstr = ','.join(f'{c.name}:{c.source}:{c.div}'
                                for c in self._sub_clocks.values())
         groupstr = ','.join(f'{g.name}:{"+".join(sorted(g.sources))}'
                             for g in self._clock_groups.values())
-        swcfgstr = ','.join(g.name for g in self._clock_groups.values()
+        swcgstr = ','.join(g.name for g in self._clock_groups.values()
                             if g.sw_cg)
         hintstr = ','.join(g.name for g in self._clock_groups.values()
                             if g.hint)
-        self.add_pair(clkdata, 'topclocks', topclockstr)
+        self.add_pair(clkname, clkdata, 'topclocks', topclockstr)
         if clkrefname:
-            self.add_pair(clkdata, 'refclock', clkrefname)
-        self.add_pair(clkdata, 'subclocks', subclockstr)
-        self.add_pair(clkdata, 'groups', groupstr)
-        self.add_pair(clkdata, 'swcfg', swcfgstr)
-        self.add_pair(clkdata, 'hint', hintstr)
+            self.add_pair(clkname, clkdata, 'refclock', clkrefname)
+        self.add_pair(clkname, clkdata, 'subclocks', subclockstr)
+        self.add_pair(clkname, clkdata, 'groups', groupstr)
+        self.add_pair(clkname, clkdata, 'swcg', swcgstr)
+        self.add_pair(clkname, clkdata, 'hint', hintstr)
         cfg[f'ot_device "{clkname}"'] = clkdata
 
     def _generate_pwrmgr(self, cfg: ConfigParser,
@@ -469,7 +502,7 @@ class OtConfiguration:
         pwrdata = {}
         clockstr = ','.join(c.name for c in self._top_clocks.values()
                                if not c.aon)
-        self.add_pair(pwrdata, 'clocks', clockstr)
+        self.add_pair(pwrname, pwrdata, 'clocks', clockstr)
         cfg[f'ot_device "{pwrname}"'] = pwrdata
 
 
@@ -495,6 +528,8 @@ def main():
                            help='OTP Constant SV file (default: auto)')
         files.add_argument('-l', '--lifecycle', metavar='SV',
                            help='LifeCycle SV file (default: auto)')
+        files.add_argument('-S', '--secrets', metavar='HJSON',
+                           help='Secret HJSON file (default: auto)')
         files.add_argument('-t', '--topcfg', metavar='HJSON',
                            help='OpenTitan top HJSON config file '
                                 '(default: auto)')
@@ -507,6 +542,10 @@ def main():
         mods.add_argument('-a', '--action', choices=actions,
                           action='append', default=[],
                           help=f'Action(s) to perform, default: {actions[0]}')
+        mods.add_argument('-x', '--exclude', action='append',
+                          metavar='DEVICE.NAME', default=[],
+                          help='Discard any property from DEVICE that starts '
+                               'with NAME (may be repeated)')
         extra = argparser.add_argument_group(title='Extras')
         extra.add_argument('-v', '--verbose', action='count',
                            help='increase verbosity')
@@ -515,7 +554,7 @@ def main():
         args = argparser.parse_args()
         debug = args.debug
 
-        log = configure_loggers(args.verbose, 'cfggen', 'otp')[0]
+        log = configure_loggers(args.verbose, 'cfggen', 'lc', 'otp')[0]
 
         if _HJSON_ERROR:
             argparser.error(f'Missing HJSON module: {_HJSON_ERROR}')
@@ -541,11 +580,11 @@ def main():
             if not isfile(topcfg):
                 argparser.error(f"No such file '{topcfg}'")
             log.info("Top config: '%s'", topcfg)
-            cfg.load_top_config(topcfg)
+            cfg.load_config(topcfg)
         else:
             if not isfile(topcfg):
                 argparser.error(f'No such top file: {topcfg}')
-            cfg.load_top_config(topcfg)
+            cfg.load_config(topcfg)
             ltop = cfg.top_name
             if not ltop:
                 argparser.error('Unknown top name')
@@ -615,15 +654,36 @@ def main():
             argparser.error(f"No such file '{ocpath}'")
         log.debug(f"'{ocfilename}' location: '%s'", ocpath)
 
+        secpath = args.secrets
+        if secpath:
+            if not isfile(secpath):
+                argparser.error('No such secret file: {secpath}')
+        else:
+            sec_constant_locations = [
+                # master branch development environment
+                joinpath(top_dir,
+                         f'data/autogen/{top}.secrets.testing.gen.hjson'),
+                # (obsolete) master branch development environment
+                joinpath(top_dir, f'data/autogen/{top}.secrets.dev.gen.hjson'),
+            ]
+            for maybe_secpath in sec_constant_locations:
+                if isfile(maybe_secpath):
+                    secpath = maybe_secpath
+                    break
+
         cfg.load_lifecycle(lcpath)
         cfg.load_otp_constants(ocpath)
+        cfg.load_constants(secpath)
+        cfg.prepare()
+        cfg.exclude(args.exclude)
+
         with open(args.out, 'wt') if args.out else sys.stdout as ofp:
             if 'config' in args.action:
                 cfg.save(topvar, args.socid, args.count, ofp)
             if 'clock' in args.action:
                 cfg.show_clocks(ofp)
 
-    except (IOError, ValueError, ImportError) as exc:
+    except (ArgError, IOError, ValueError, ImportError) as exc:
         print(f'\nError: {exc}', file=sys.stderr)
         if debug:
             print(format_exc(chain=False), file=sys.stderr)

--- a/scripts/opentitan/cfggen.py
+++ b/scripts/opentitan/cfggen.py
@@ -577,9 +577,13 @@ def main():
         lcpath = args.lifecycle
         if not lcpath:
             lc_constant_locations = [
+                # master branch development environment
                 joinpath(top_dir, f'rtl/autogen/testing/{lcfilename}'),
+                # (obsolete) master branch development environment
                 joinpath(top_dir, f'rtl/autogen/dev/{lcfilename}'),
+                # (obsolete) master branch
                 joinpath(top_dir, f'rtl/autogen/{lcfilename}'),
+                # earlgrey_1.0.0 branch
                 joinpath(ot_dir, f'hw/ip/lc_ctrl/rtl/{lcfilename}'),
             ]
             for maybe_lcpath in lc_constant_locations:
@@ -596,7 +600,9 @@ def main():
         ocpath = args.otpconst
         if not ocpath:
             otp_constant_locations = [
+                # master branch
                 joinpath(top_dir, f'ip_autogen/otp_ctrl/rtl/{ocfilename}'),
+                # earlgrey_1.0.0 branch
                 joinpath(ot_dir, f'hw/ip/otp_ctrl/rtl/{ocfilename}'),
             ]
             for maybe_ocpath in otp_constant_locations:

--- a/scripts/opentitan/cfggen.py
+++ b/scripts/opentitan/cfggen.py
@@ -577,6 +577,7 @@ def main():
         lcpath = args.lifecycle
         if not lcpath:
             lc_constant_locations = [
+                joinpath(top_dir, f'rtl/autogen/testing/{lcfilename}'),
                 joinpath(top_dir, f'rtl/autogen/dev/{lcfilename}'),
                 joinpath(top_dir, f'rtl/autogen/{lcfilename}'),
                 joinpath(ot_dir, f'hw/ip/lc_ctrl/rtl/{lcfilename}'),

--- a/scripts/opentitan/otptool.py
+++ b/scripts/opentitan/otptool.py
@@ -71,6 +71,8 @@ def main():
                            help='output filename (default to stdout)')
         files.add_argument('-r', '--raw',
                            help='QEMU OTP raw image file')
+        files.add_argument('-x', '--export',
+                           help='Export data to a VMEM file')
         params = argparser.add_argument_group(title='Parameters')
         # pylint: disable=unsubscriptable-object
         params.add_argument('-k', '--kind',
@@ -130,6 +132,9 @@ def main():
                               help='set a bit at specified location')
         commands.add_argument('--toggle-bit', action='append',  default=[],
                               help='toggle a bit at specified location')
+        commands.add_argument('--write', action='append',
+                              metavar='ADDR/HEXBYTES', default=[],
+                              help='write bytes at specified location')
         commands.add_argument('--patch-token', action='append',
                               metavar='NAME=VALUE', default=[],
                               help='change a LC hashed token, using Rust file')
@@ -149,8 +154,8 @@ def main():
 
         if not (args.vmem or args.raw):
             if any((args.show, args.digest, args.ecc_recover, args.clear_bit,
-                    args.set_bit, args.toggle_bit, args.change, args.erase,
-                    args.fix_digest)):
+                    args.set_bit, args.toggle_bit, args.write, args.change,
+                    args.erase, args.fix_digest)):
                 argparser.error('At least one raw or vmem file is required')
 
         if not args.vmem and args.kind:
@@ -172,7 +177,13 @@ def main():
             alter_bits.append([])
             for bitdef in bitdefs:
                 try:
-                    offset, bit = (HexInt.parse(x) for x in bitdef.split('/'))
+                    soff, sdata = bitdef.split('/', 1)
+                    if soff[1] == 'h':
+                        offset = HexInt.parse(soff.replace('h', 'x'))
+                        offset *= 2
+                    else:
+                        offset = HexInt.parse(soff)
+                    bit = HexInt.parse(sdata)
                 except ValueError as exc:
                     argparser.error(f"Invalid bit specifier '{bitdef}', should "
                                     f"be <offset>/<bit_num> format: {exc}")
@@ -367,6 +378,19 @@ def main():
                     getattr(otp, f'{bitact}_bits')(alter_bits[pos])
                 check_update = True
 
+            for write in args.write:
+                try:
+                    saddr, sdata = write.split('/', 1)
+                    if saddr[1] == 'h':
+                        addr = HexInt.parse(saddr.replace('h', 'x'))
+                        addr *= 2
+                    else:
+                        addr = HexInt.parse(saddr)
+                    data = unhexlify(sdata)
+                except ValueError as exc:
+                    argparser.error(f'Invalid write syntax: {write} {exc}')
+                otp.change_data(addr, data)
+
             if args.fix_ecc:
                 otp.fix_ecc()
                 check_update = True
@@ -382,6 +406,10 @@ def main():
             if args.raw and not args.vmem:
                 if not args.update and check_update:
                     log.warning('OTP content modified, image file not updated')
+
+            if args.export:
+                with open(args.export, 'wt') as xfp:
+                    otp.save_vmem(xfp)
 
     except (IOError, ValueError, ImportError) as exc:
         print(f'\nError: {exc}', file=sys.stderr)

--- a/scripts/opentitan/pyot.py
+++ b/scripts/opentitan/pyot.py
@@ -61,6 +61,7 @@ def main():
     tmp_result: Optional[str] = None
     result_file: Optional[str] = None
     rlog: Optional[RemoteLogService] = None
+    ret = None
     try:
         args: Optional[Namespace] = None
         desc = sys.modules[__name__].__doc__.split('.', 1)[0].strip()
@@ -326,10 +327,12 @@ def main():
             rfmt = ResultFormatter()
             try:
                 rfmt.load(result_file)
-                rfmt.show(True)
+                rfmt.show(True, QEMUExecuter.RESULT_MAP.get(ret))
             # pylint: disable=broad-except
             except Exception as exc:
                 print(f'Cannot generate result file: {exc}', file=sys.stderr)
+                if debug:
+                    print(format_exc(chain=False), file=sys.stderr)
         if tmp_result and isfile(tmp_result):
             unlink(tmp_result)
 

--- a/scripts/opentitan/pyot.py
+++ b/scripts/opentitan/pyot.py
@@ -35,7 +35,7 @@ sys.path.append(QEMU_PYPATH)
 # pylint: disable=import-error
 
 from ot.pyot import DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_FACTOR
-from ot.pyot.executer import QEMUExecuter
+from ot.pyot.qemu.executer import QEMUExecuter
 from ot.pyot.filemgr import FileManager
 from ot.pyot.util import ResultFormatter
 from ot.util.log import ColorLogFormatter, RemoteLogService, configure_loggers

--- a/scripts/opentitan/pyot.py
+++ b/scripts/opentitan/pyot.py
@@ -36,9 +36,10 @@ sys.path.append(QEMU_PYPATH)
 
 from ot.pyot import DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_FACTOR
 from ot.pyot.executer import QEMUExecuter
-from ot.pyot.filemgr import QEMUFileManager
+from ot.pyot.filemgr import FileManager
 from ot.pyot.util import ResultFormatter
 from ot.util.log import ColorLogFormatter, RemoteLogService, configure_loggers
+from ot.util.misc import flatten
 
 DEFAULT_MACHINE = 'ot-earlgrey'
 DEFAULT_DEVICE = 'localhost:8000'
@@ -207,7 +208,7 @@ def main():
                                 debug=args.debug, info=args.info,
                                 warning=args.warn)[0]
 
-        qfm = QEMUFileManager(args.keep_tmp)
+        qfm = FileManager(args.keep_tmp)
         qfm.set_qemu_src_dir(qemu_dir)
 
         if args.log_udp != 0:
@@ -243,7 +244,7 @@ def main():
                         continue
                 optname = f'--{arg}' if len(arg) > 1 else f'-{arg}'
                 if isinstance(val, list):
-                    val = QEMUExecuter.flatten(v.split() for v in val)
+                    val = flatten(v.split() for v in val)
                     for valit in val:
                         jargs.append(f'{optname}={qfm.interpolate(valit)}')
                 else:

--- a/scripts/opentitan/verilate.py
+++ b/scripts/opentitan/verilate.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+
+"""Verilator wrapper."""
+
+# Copyright (c) 2025 Rivos, Inc.
+# SPDX-License-Identifier: Apache2
+
+from atexit import register
+from collections import deque
+from fcntl import fcntl, F_GETFL, F_SETFL
+from io import BufferedRandom, TextIOWrapper
+from os import O_NONBLOCK, getcwd, getenv, rename, symlink, unlink, walk
+from os.path import (basename, dirname, exists, isdir, isfile, islink,
+                     join as joinpath, normpath, realpath, splitext)
+from select import POLLIN, POLLERR, POLLHUP, poll as sel_poll
+from shutil import copyfile, rmtree
+from subprocess import Popen, PIPE, TimeoutExpired
+from sys import exit as sysexit, modules, stderr
+from tempfile import mkdtemp, mkstemp
+from threading import Thread
+from time import sleep, time as now
+from traceback import format_exc
+from typing import Optional, Union
+
+import logging
+import re
+import sys
+
+QEMU_PYPATH = joinpath(dirname(dirname(dirname(normpath(__file__)))),
+                       'python', 'qemu')
+sys.path.append(QEMU_PYPATH)
+
+# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-order
+# pylint: disable=import-error
+
+getLogger = logging.getLogger
+
+from ot.util.argparse import ArgumentParser, FileType  # noqa: E402
+from ot.util.file import guess_file_type, make_vmem_from_elf
+from ot.util.log import ColorLogFormatter, configure_loggers
+
+VeriVcpDescriptor = tuple[str, BufferedRandom, bytearray, logging.Logger]
+
+DEFAULT_TIMEOUT = 10.0 * 60
+"""Default execution timeout."""
+
+
+class VtorFileManager:
+    """File manager.
+
+       Handle temporary directories and files.
+
+       :param keep_temp: do not automatically discard generated files on exit
+       :param tmp_dir: store the temporary files in the specified directory
+    """
+
+    def __init__(self, keep_temp: bool = False, tmp_dir: Optional[str] = None):
+        self._log = getLogger('vtor.file')
+        self._keep_temp = keep_temp
+        self._base_tmp_dir = tmp_dir
+        self._tmp_dir: Optional[str] = None
+        register(self._cleanup)
+
+    @property
+    def tmp_dir(self) -> str:
+        """Provides the main temporary directory for executing Verilator."""
+        if not self._tmp_dir:
+            self._tmp_dir = mkdtemp(prefix='verilator_ot_dir_',
+                                    dir=self._base_tmp_dir)
+        return self._tmp_dir
+
+    def _cleanup(self):
+        if self._tmp_dir and isdir(self._tmp_dir):
+            if self._keep_temp:
+                self._log.warning('Preserving temp dir %s', self._tmp_dir)
+                return
+            self._log.debug('Removing temp dir %s', self._tmp_dir)
+            rmtree(self._tmp_dir)
+            self._tmp_dir = None
+
+
+class VtorExecuter:
+    """Verilator wrapper.
+
+        -c|--term-after-cycles=N
+    """
+
+    VMEM_OFFSET = 0
+    """Offset when converting BM test to VMEM file."""
+
+    ANSI_CRE = re.compile(rb'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
+    """ANSI escape sequences."""
+
+    DV_CRE = re.compile(r'^(\d+):\s\(../.*?\)\s(.*)$')
+    """DV macro messages."""
+
+    DEADLOCK = 125
+    """Default error code when Verilator is stuck."""
+
+    def __init__(self, vfm: VtorFileManager, verilator: str,
+                 profile: Optional[str], debug: bool = False):
+        self._log = getLogger('vtor.exec')
+        self._vlog = getLogger('vtor.out')
+        self._profile = profile
+        self._debug = debug
+        self._verilator = verilator
+        self._fm = vfm
+        # parsed communication ports from Verilator
+        self._ports: dict[str, Union[int, str]] = {}
+        # where Verilator stores the execution log file
+        self._xlog_path: Optional[str] = None
+        # where to copy the execution log file, if requested
+        self._dest_log_path: Optional[str] = None
+        # where to create a symbolic list to the execution log file
+        self._link_log_path: Optional[str] = None
+        self._vcps: dict[int, VeriVcpDescriptor] = {}
+        self._poller = sel_poll()
+        self._resume = False
+        self._threads: list[Thread] = []
+
+    @classmethod
+    def _simplifly_cli(cls, args: list[str]) -> str:
+        """Shorten the Verilator commmand line."""
+        arggen = (','.join((basename(path) for path in arg.split(','))) for arg in args)
+        return ' '.join(arggen)
+
+    def link_log_file(self, logpath: str) -> None:
+        """Request to create a link to the live log file."""
+        self._link_log_path = logpath
+
+    def save_execution_log_file(self, logpath: str) -> None:
+        """Request to store the execution log file."""
+        self._dest_log_path = logpath
+
+    def verilate(self, rom: str, flash: str, otp: Optional[str],
+                 gen_wave: bool = False, timeout: float = None,
+                 cycles: Optional[int] = None) -> int:
+        """Execute a Verilator simulation."""
+        workdir = self._fm.tmp_dir
+        self._log.debug('Work dir: %s', workdir)
+        if not timeout:
+            timeout = DEFAULT_TIMEOUT
+        ret = None
+        xend = None
+        proc = None
+        simulate = False
+        log_q: Optional[deque] = None
+        flash_file = self._convert_app_file(flash)
+        profile_file = None
+        try:
+            args = [self._verilator]
+            args.append(f'--meminit=rom,{rom}')
+            args.append(f'--meminit=flash0,{flash_file}')
+            if self._profile:
+                args.append('--prof-pgo')
+                profile_file = normpath(self._profile)
+                if isfile(profile_file):
+                    self._log.info('Using profile file %s', profile_file)
+                    args.append(profile_file)
+            if otp:
+                args.append(f'--meminit=otp,{otp}')
+            if cycles:
+                args.append(f'--term-after-cycles={cycles}')
+            if gen_wave:
+                wave_name = f'{splitext(basename(flash))[0]}.fst'
+                wave_name = realpath(joinpath(getcwd(), wave_name))
+                args.append(f'--trace={wave_name}')
+            self._log.debug('Executing Verilator as %s',
+                            self._simplifly_cli(args))
+            # pylint: disable=consider-using-with
+            proc = Popen(args,
+                         bufsize=1, cwd=workdir,
+                         stdout=PIPE, stderr=PIPE,
+                         encoding='utf-8', errors='ignore', text=True)
+            try:
+                proc.wait(0.1)
+            except TimeoutExpired:
+                pass
+            else:
+                ret = proc.returncode
+                self._log.error('Verilator bailed out: %d', ret)
+                raise OSError()
+            # if execution starts and the execution log should be generated
+            # discards any previous file to avoid leaving a previous version of
+            # this file that would not match the current session
+            self._discard_exec_log()
+            log_q = deque()
+            self._resume = True
+            for pos, stream in enumerate(('out', 'err')):
+                thread = Thread(target=self._vtor_logger,
+                                name=f'veri_{stream}_logger',
+                                args=(getattr(proc, f'std{stream}'), log_q,
+                                      bool(pos)),
+                                daemon=True)
+                self._threads.append(thread)
+                thread.start()
+            abstimeout = float(timeout) + now()
+            while now() < abstimeout:
+                while log_q:
+                    err, qline = log_q.popleft()
+                    level = logging.ERROR if err else logging.INFO
+                    if not err and not simulate:
+                        if qline.startswith('Simulation running, '):
+                            simulate = True
+                            self._connect_vcps(2.0)
+                            self._log.info('Simulation begins')
+                        else:
+                            self._parse_verilator_info(qline)
+                    else:
+                        qline = self._parse_verilator_output(qline, err)
+                        if qline:
+                            self._vlog.log(level, qline)
+                    break
+                else:
+                    sleep(0.005)
+                xret = proc.poll()
+                if xret is None:
+                    xret = self._process_vcps()
+                if xret is not None:
+                    if xend is None:
+                        xend = now()
+                    ret = xret
+                    break
+        except (OSError, ValueError) as exc:
+            if self._debug:
+                print(format_exc(chain=False), file=stderr)
+            if ret is None:
+                self._log.error('Unable to execute Verilator: %s', exc)
+                if proc and proc.poll() is not None:
+                    ret = proc.returncode
+                else:
+                    ret = self.DEADLOCK
+        finally:
+            self._disconnect_vcps()
+            if proc:
+                # leave some for Verilator to cleanly complete and flush its
+                # streams
+                wait = 0.5
+                if xend is None:
+                    xend = now()
+                waited_time = now()
+                proc.terminate()
+                try:
+                    # go through if Verilator has exited on its own
+                    proc.wait(wait)
+                except TimeoutExpired:
+                    # otherwise kill it
+                    self._log.error('Force-killing Verilator')
+                    proc.kill()
+                # ensure completion delay is always satisfied whatever the
+                # termination reason
+                waited_time = now() - waited_time
+                rem = wait - waited_time
+                if rem > 0.0:
+                    sleep(rem)
+                if ret is None:
+                    ret = proc.returncode
+                self._resume = False
+                timeout_count = 10
+                while self._threads:
+                    timeout_count -= 1
+                    if not timeout_count:
+                        self._log.error('Cannot terminate %s',
+                                        ', '.join((t.name
+                                                   for t in self._threads)))
+                        break
+                    thread = self._threads.pop(0)
+                    thread.join(timeout=0.2)
+                    if thread.is_alive():
+                        self._threads.append(thread)
+                # retrieve the remaining log messages
+                while log_q:
+                    err, qline = log_q.popleft()
+                    level = logging.ERROR if err else logging.INFO
+                    self._vlog.log(level, qline)
+                for msg, logger in zip(proc.communicate(timeout=0.1),
+                                       (self._vlog.info, self._vlog.error)):
+                    # should have been captured by the logger threads
+                    for line in msg.splitlines():
+                        line = line.rstrip()
+                        if line:
+                            logger(line)
+                if log_q:
+                    # should never happen
+                    self._vlog.error('Lost traces')
+                self._save_exec_log()
+            tmp_profile = joinpath(workdir, 'profile.vlt')
+            if isfile(tmp_profile) and profile_file:
+                self._log.info('Saving profile file as %s', profile_file)
+                copyfile(tmp_profile, profile_file)
+        return abs(ret or 0)
+
+    def _vtor_logger(self, stream: TextIOWrapper, queue: deque, err: bool) \
+            -> None:
+        # worker thread, blocking on VM stdout/stderr
+        if not stream:
+            self._log.error('No Verilator std%s stream',
+                            'err' if err else 'out')
+            return
+        while self._resume:
+            try:
+                line = stream.readline().rstrip()
+            # pylint: disable=broad-except
+            except Exception as exc:
+                # do not raise an error if stream disappears
+                self._log.error('%s', exc)
+                if self._debug:
+                    print(format_exc(chain=False), file=stderr)
+                break
+            if line:
+                queue.append((err, line))
+            else:
+                sleep(0.005)
+        self._log.debug('End of std%s logger thread', 'err' if err else 'out')
+
+    def _parse_verilator_info(self, line: str) -> None:
+        """Parse initial verilator output which contains communication port
+           descriptors as strings.
+        """
+        if line.startswith('remote_bitbang_port '):
+            self._ports['jtag'] = int(line.split(' ')[1])
+            return
+        if line.startswith('GPIO: FIFO pipes'):
+            parts = line.split(' ')
+            for gdir in ('read', 'write'):
+                pos = parts.index(f'({gdir})')
+                if pos > 0:
+                    self._ports[f'gpio_{gdir[0]}'] = parts[pos-1]
+            return
+        if any((line.startswith(f'{dev}: Created ')
+                for dev in ('UART', 'SPI'))):
+            parts = line.split('.')[0].split(' ')
+            self._ports[parts[-1]] = parts[-3]
+            return
+
+    def _parse_verilator_output(self, line: str, err: bool) -> str:
+        if err:
+            return line
+        dvmo = self.DV_CRE.match(line)
+        if dvmo:
+            return ' '.join(dvmo.groups())
+        if not line.startswith('TOP.chip_sim_tb'):
+            return line
+        if not self._xlog_path:
+            trace_msg = 'Writing execution trace to '
+            pos = line.find(trace_msg)
+            if pos >= 0:
+                self._xlog_path = realpath(joinpath(self._fm.tmp_dir,
+                                                    line[pos+len(trace_msg):]))
+                self._log.info('Execution log: %s', self._xlog_path)
+                if self._link_log_path:
+                    tmpslnk = f'{self._link_log_path}.tmp'
+                    if islink(tmpslnk):
+                        unlink(tmpslnk)
+                    elif exists(tmpslnk):
+                        raise FileExistsError(f'File {tmpslnk} already exists')
+                    symlink(self._xlog_path, tmpslnk)
+                    rename(tmpslnk, self._link_log_path)
+                return ''
+        return line
+
+    def _connect_vcps(self, delay: float):
+        connect_map = {k: v for k, v in self._ports.items()
+                       if k.startswith('uart')}
+        timeout = now() + delay
+        # ensure that QEMU starts and give some time for it to set up
+        # when multiple VCPs are set to 'wait', one VCP can be connected at
+        # a time, i.e. QEMU does not open all connections at once.
+        vcp_lognames = []
+        vcplogname = 'vtor'
+        vcplognames = []
+        while connect_map:
+            if now() > timeout:
+                minfo = ', '.join(f'{d} @ {r}'
+                                  for d, r in connect_map.items())
+                raise TimeoutError(f'Cannot connect to Verilator VCPs: {minfo}')
+            connected = []
+            for vcpid, ptyname in connect_map.items():
+                try:
+                    # pylint: disable=pylint: consider-using-with
+                    vcp = open(ptyname, 'rb+', buffering=0)
+                    flags = fcntl(vcp, F_GETFL)
+                    fcntl(vcp, F_SETFL, flags | O_NONBLOCK)
+                    connected.append(vcpid)
+                    vcp_lognames.append(vcpid)
+                    vcp_log = logging.getLogger(f'{vcplogname}.{vcpid}')
+                    vcplognames.append(vcpid)
+                    vcp_fno = vcp.fileno()
+                    assert vcp_fno not in self._vcps
+                    self._vcps[vcp_fno] = (vcpid, vcp, bytearray(), vcp_log)
+                    self._log.debug('VCP %s connected to pty %s',
+                                    vcpid, ptyname)
+                    self._poller.register(vcp, POLLIN | POLLERR | POLLHUP)
+                except ConnectionRefusedError:
+                    continue
+                except OSError as exc:
+                    self._log.error('Cannot setup Verilator VCP connection %s: '
+                                    '%s', vcpid, exc)
+                    print(format_exc(chain=False), file=stderr)
+                    raise
+            # removal from dictionary cannot be done while iterating it
+            for vcpid in connected:
+                del connect_map[vcpid]
+        self._colorize_vcp_log(vcplogname, vcplognames)
+
+    def _disconnect_vcps(self):
+        for _, vcp, _, _ in self._vcps.values():
+            self._poller.unregister(vcp)
+            vcp.close()
+        self._vcps.clear()
+
+    def _process_vcps(self) -> Optional[int]:
+        ret = None
+        for vfd, event in self._poller.poll(0.01):
+            if event in (POLLERR, POLLHUP):
+                self._poller.modify(vfd, 0)
+                continue
+            _, vcp, vcp_buf, vcp_log = self._vcps[vfd]
+            try:
+                data = vcp.read(256)
+            except TimeoutError:
+                self._log.error('Unexpected timeout w/ poll on %s', vcp)
+                continue
+            if not data:
+                continue
+            vcp_buf += data
+            lines = vcp_buf.split(b'\n')
+            vcp_buf[:] = bytearray(lines[-1])
+            for line in lines[:-1]:
+                line = self.ANSI_CRE.sub(b'', line)
+                sline = line.decode('utf-8', errors='ignore').rstrip()
+                level = logging.INFO
+                vcp_log.log(level, sline)
+            if ret is not None:
+                # match for exit sequence on current VCP
+                break
+        return ret
+
+    def _colorize_vcp_log(self, logbase: str, lognames: list[str]) -> None:
+        vlog = logging.getLogger(logbase)
+        clr_fmt = None
+        while vlog:
+            for hdlr in vlog.handlers:
+                if isinstance(hdlr.formatter, ColorLogFormatter):
+                    clr_fmt = hdlr.formatter
+                    break
+            vlog = vlog.parent
+        if not clr_fmt:
+            return
+        for color, logname in enumerate(sorted(lognames)):
+            clr_fmt.add_logger_colors(f'{logbase}.{logname}', color)
+
+    def _discard_exec_log(self) -> None:
+        if not self._dest_log_path or not isfile(self._dest_log_path):
+            return
+        try:
+            unlink(self._dest_log_path)
+            self._log.debug('Old execution log file discarded')
+        except OSError as exc:
+            self._log.error('Cannot remove previous execution log file: %s',
+                            exc)
+
+    def _save_exec_log(self) -> None:
+        if not self._dest_log_path:
+            return
+        if not self._xlog_path:
+            self._log.error('No execution log file found')
+            return
+        if not isfile(self._xlog_path):
+            self._log.error('Missing execution log file')
+            return
+        copyfile(self._xlog_path, self._dest_log_path)
+
+    def _convert_app_file(self, filepath: str) -> str:
+        kind = guess_file_type(filepath)
+        if kind == 'vmem':
+            # no conversion required
+            return filepath
+        if kind == 'elf':
+            prefix = f'{splitext(basename(filepath))[0]}.'
+            vmem_no, vmem_path = mkstemp(suffix='.vmem', prefix=prefix,
+                                         dir=self._fm.tmp_dir, text=True)
+            with open(vmem_no, 'wt') as vfp:
+                make_vmem_from_elf(filepath, vfp, offset=self.VMEM_OFFSET,
+                                   chunksize=8, offsetsize=8)
+            self._log.debug('Using temp application file %s',
+                            basename(vmem_path))
+            return vmem_path
+        raise RuntimeError(f'Unsupported application file type: {kind}')
+
+
+def main():
+    """Main routine."""
+    debug = False
+    try:
+        desc = modules[__name__].__doc__.split('.', 1)[0].strip()
+        argparser = ArgumentParser(description=f'{desc}.')
+        files = argparser.add_argument_group(title='Files')
+        files.add_argument('flash', nargs=1, type=FileType('rb'),
+                           metavar='ELF|VMEM', help='flash file')
+        files.add_argument('-V', '--verilator',
+                           help='Verilator executable')
+        files.add_argument('-R', '--rom', type=FileType('rt'),
+                           metavar='VMEM', required=True,
+                           help='ROM file')
+        files.add_argument('-O', '--otp', type=FileType('rt'),
+                           metavar='VMEM',
+                           help='OTP file')
+        files.add_argument('-K', '--keep-tmp', action='store_true',
+                           help='do not automatically remove temporary files '
+                                'and dirs on exit')
+        files.add_argument('-D', '--tmp-dir',
+                           help='store the temporary files in the specified '
+                                'directory')
+        veri = argparser.add_argument_group(title='Verilator')
+        veri.add_argument('-C', '--cycles', type=int,
+                          help='exit after the specified cycles')
+        veri.add_argument('-k', '--timeout', metavar='SECONDS', type=float,
+                          help=f'exit after the specified seconds '
+                               f'(default: {DEFAULT_TIMEOUT} secs)')
+        veri.add_argument('-l', '--link-log', metavar='LINK',
+                          help='create a symbolic link to the log file')
+        veri.add_argument('-P', '--profile', metavar='FILE',
+                          help='enable/manage profile file')
+        veri.add_argument('-w', '--wave', action='store_true',
+                          help='generate output wave file')
+        veri.add_argument('-x', '--execution-log', metavar='FILE',
+                          help='save execution log')
+        extra = argparser.add_argument_group(title='Extras')
+        extra.add_argument('-v', '--verbose', action='count',
+                           help='increase verbosity')
+        extra.add_argument('-d', '--debug', action='store_true',
+                           help='enable debug mode')
+        extra.add_argument('--log-time', action='store_true',
+                           help='show local time in log messages')
+        args = argparser.parse_args()
+        debug = args.debug
+
+        log = configure_loggers(args.verbose, 'vtor', -1, 'elf',
+                                name_width=12, ms=args.log_time)[0]
+
+        # let ArgumentParser validate the paths
+        flash = realpath(args.flash[0].name)
+        otp = realpath(args.otp.name) if args.otp else None
+        rom = realpath(args.rom.name)
+        args.flash[0].close()
+        args.rom.close()
+        if args.otp:
+            args.otp.close()
+
+        if args.tmp_dir and not isdir(args.tmp_dir):
+            argparser.error('Invalid directory for temporary files')
+
+        verilator = args.verilator or getenv('VERILATOR')
+        if not verilator:
+            argparser.error('Verilator tool not specified')
+        if not isfile(verilator) and isdir(verilator):
+            top_dir = realpath(verilator)
+            for dirpath, _, files in walk(top_dir):
+                if 'Vchip_sim_tb' in files:
+                    verilator = realpath(joinpath(dirpath, 'Vchip_sim_tb'))
+                    if isfile(verilator):
+                        short_veri = verilator[len(top_dir)+1:]
+                        log.debug('Found Verilator tool as %s', short_veri)
+                        break
+        if not isfile(verilator):
+            argparser.error('Verilator tool not found')
+
+        vfm = VtorFileManager(args.keep_tmp, args.tmp_dir)
+        vtor = VtorExecuter(vfm, verilator, args.profile, debug)
+        if args.execution_log:
+            if not isdir(realpath(dirname(args.execution_log))):
+                argparser.error('Invalid directory for execution log file')
+            vtor.save_execution_log_file(args.execution_log)
+        if args.link_log:
+            vtor.link_log_file(args.link_log)
+        ret = vtor.verilate(rom, flash, otp, args.wave, timeout=args.timeout,
+                            cycles=args.cycles)
+
+        sysexit(ret)
+    # pylint: disable-msg=broad-except
+    except Exception as exc:
+        print(f'\nError: {exc}', file=stderr)
+        if debug:
+            print(format_exc(chain=False), file=stderr)
+        sysexit(1)
+    except KeyboardInterrupt:
+        sysexit(2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Several fixes and improvements, relevant parts are:
- improvements to cfggen.py tool to support several versions of the OpenTitan repo. This fixes https://github.com/lowRISC/qemu/issues/174.
- improvements to autoreg.py tool and a new autotop.py tool (helpers to generate template code for devices and tops/machines)
- a new verilate.py tool to help running apps with Verilator outside of the OpenTitan Bazel environment
- update Darjeeling machine to match latest OpenTitan master
- added default configuration files for Earlgrey 1.0.0 and Darjeeling master (in `docs/config/opentitan`)
- removed default seeds/secrets from `ot_earlgrey` and `ot_darjeeling` machines

Note: Noticed when implementing the last two points that the hard-coded LC values in `ot_earlgrey.c` were not matching OpenTitan `earlgrey_1.0.0` branch. I suppose this was not an issue because OpenTitan Bazel setup generates and use a config on-the-fly.