### PR TITLE
[ot] hw/opentitan: spi_device: fix off-by-one last_read_addr

### DIFF
--- a/hw/opentitan/ot_spi_device.c
+++ b/hw/opentitan/ot_spi_device.c
@@ -706,18 +706,18 @@ static void ot_spi_device_clear_modes(OtSPIDeviceState *s)
 
     timer_del(f->irq_timer);
     FLASH_CHANGE_STATE(s, IDLE);
-    f->address = 0;
-    f->last_read_addr = 0;
+    f->address = 0u;
+    f->last_read_addr = 0u;
     f->cmd_info = UINT32_MAX;
-    f->pos = 0;
-    f->len = 0;
+    f->pos = 0u;
+    f->len = 0u;
     f->type = SPI_FLASH_CMD_NONE;
     g_assert(s->sram);
     f->payload = &((uint8_t *)s->sram)[SPI_SRAM_PAYLOAD_OFFSET];
     f->payload += SPI_SRAM_INGRESS_OFFSET;
-    memset(f->buffer, 0, SPI_FLASH_BUFFER_SIZE);
+    memset(f->buffer, 0u, SPI_FLASH_BUFFER_SIZE);
 
-    memset(s->sram, 0, SRAM_SIZE);
+    memset(s->sram, 0u, SRAM_SIZE);
 }
 
 static uint32_t ot_spi_device_get_status(const OtSPIDeviceState *s)

--- a/hw/opentitan/ot_spi_device.c
+++ b/hw/opentitan/ot_spi_device.c
@@ -394,6 +394,7 @@ typedef struct {
     unsigned len; /* Meaning depends on command and current state */
     unsigned slot; /* Command slot */
     uint32_t address; /* Address tracking */
+    uint32_t last_read_addr; /* Last address read before increment */
     uint32_t cmd_info; /* Selected command info slot */
     uint8_t *src; /* Selected read data source (alias) */
     uint8_t *payload; /* Selected write data sink (alias) */
@@ -706,6 +707,7 @@ static void ot_spi_device_clear_modes(OtSPIDeviceState *s)
     timer_del(f->irq_timer);
     FLASH_CHANGE_STATE(s, IDLE);
     f->address = 0;
+    f->last_read_addr = 0;
     f->cmd_info = UINT32_MAX;
     f->pos = 0;
     f->len = 0;
@@ -841,9 +843,10 @@ static void ot_spi_device_release(OtSPIDeviceState *s)
          *  Read SFDP command’s address."
          */
         if (ot_spi_device_is_hw_read_command(s) &&
-            !ot_spi_device_is_mailbox_match(s, f->address)) {
-            trace_ot_spi_device_update_last_read_addr(s->ot_id, f->address);
-            s->spi_regs[R_LAST_READ_ADDR] = f->address;
+            !ot_spi_device_is_mailbox_match(s, f->last_read_addr)) {
+            trace_ot_spi_device_update_last_read_addr(s->ot_id,
+                                                      f->last_read_addr);
+            s->spi_regs[R_LAST_READ_ADDR] = f->last_read_addr;
         }
         FLASH_CHANGE_STATE(s, IDLE);
         break;
@@ -1228,6 +1231,7 @@ static uint8_t ot_spi_device_flash_read_data(OtSPIDeviceState *s)
         }
     }
 
+    f->last_read_addr = f->address;
     f->address += 1u;
 
     /*


### PR DESCRIPTION
Read commands automatically increment the address so the last read address register was too high. We still need to do the register assignment on CS deassert to match the RTL (see Alex's comment below).

I tested this against the OpenTitan `spi_device_flash_smoketest`.