### PR TITLE
[ot] scripts/opentitan: regression: disable failing test

### DIFF
--- a/scripts/opentitan/tests-passing.txt
+++ b/scripts/opentitan/tests-passing.txt
@@ -87,7 +87,6 @@
 //sw/device/tests/crypto:rsa_3072_verify_functest_hardcoded_sim_qemu_rom_with_fake_keys
 //sw/device/tests/crypto:rsa_4096_encryption_functest_sim_qemu_rom_with_fake_keys
 //sw/device/tests/crypto:rsa_4096_signature_functest_sim_qemu_rom_with_fake_keys
-//sw/device/tests/crypto:sha256_functest_sim_qemu_rom_with_fake_keys
 //sw/device/tests/crypto:sha384_functest_sim_qemu_rom_with_fake_keys
 //sw/device/tests/crypto:sha512_functest_sim_qemu_rom_with_fake_keys
 //sw/device/tests/crypto:symmetric_keygen_functest_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
`sha256_functest` started failing when PR
https://github.com/lowRISC/opentitan/pull/28352
was merged on the OpenTitan side.

Our policy on QEMU is to disable the failing test if it was an OpenTitan change that caused it to fail.

We should separately investigate why this test is now failing, though. I wouldn't expect that particular pull request to change behaviour at first glance.