### PR TITLE
[ot] hw/opentitan: ot_hmac: Update digest before reading

### DIFF
--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -739,6 +739,10 @@ static uint64_t ot_hmac_regs_read(void *opaque, hwaddr addr, unsigned size)
     case R_DIGEST_13:
     case R_DIGEST_14:
     case R_DIGEST_15:
+        /* make sure we've processed any input blocks before reading */
+        if (!fifo8_is_empty(&s->input_fifo) && ot_hmac_get_curlen(s) != 0) {
+            ot_hmac_process_fifo(s);
+        }
         /*
          * We use a SHA library that computes in native (little) endian-ness,
          * but produces a big-endian digest upon termination. To ensure


### PR DESCRIPTION
Replaces https://github.com/lowRISC/qemu/pull/200.

As workaround for an RTL issue, most SW will on partial updates [wait for a defined number of cycles and then save the digest context of a completed message block without calling PROCESS/STOP](https://github.com/lowRISC/opentitan/blob/de6428a88f40ebc39c20c0955ccf450369cb1a2b/sw/device/lib/crypto/drivers/hmac.c#L304-L337). Currently the FIFO is only processed/emptied when it becomes too full or one of these commands is issued. Thus the current QEMU model cannot handle SW just waiting for a block to be processed instead of directly issuing commands.

To emulate this correctly, make sure we process the FIFO and compute the digest for the latest message block before any digest read. In most reads the message FIFO will be empty and thus this will be (almost) a no-op.

Fixes the regression in `sha256_functest_sim_qemu_rom_with_fake_keys` after changes to SW HMAC drivers were merged to upstream `earlgrey_1.0.0`.