### PR TITLE
`ot_keymgr`: Only go idle on reset and op_status write

### DIFF
--- a/hw/opentitan/ot_keymgr.c
+++ b/hw/opentitan/ot_keymgr.c
@@ -1836,8 +1836,6 @@ static bool ot_keymgr_main_fsm_tick(OtKeyMgrState *s)
         ot_keymgr_update_irq(s);
     } else if (op_start) {
         ot_keymgr_change_op_status(s, KEYMGR_OP_STATUS_WIP);
-    } else {
-        ot_keymgr_change_op_status(s, KEYMGR_OP_STATUS_IDLE);
     }
 
     /* lock CFG_REGWEN when an operation is ongoing */


### PR DESCRIPTION
This should fix failures in Earlgrey ROM_EXT regressions after https://github.com/lowRISC/opentitan/commit/abac2069565b737b0e2629d3faf792af8b9aa98d was (correctly) merged in upstream `earlgrey_1.0.0`. Also see discussion on the relevant RTL and SW drivers in https://github.com/lowRISC/opentitan/issues/27683. This is a case of the SW being made more stringent and catching an issue in the QEMU implementation.

The keymgr should only change its `OP_STATUS` to idle upon reset, or if it is explicitly cleared by SW. The `DONE_ERROR` and `DONE_SUCCESS` operation status values need to be latched to be queried by software, but subsequent FSM ticks (e.g. scheduled with a timer) can then change the operation status back to idle.

In HW, this value is latched and only updated when `op_start`, i.e. when the operation is ongoing. When the operation is not ongoing, the value is thus not reset back to idle outside of SW writes/resets. See the [relevant RTL](https://github.com/lowRISC/opentitan/blob/3a43edf18d1f7afba77213e125bde4f311090147/hw/ip/keymgr/rtl/keymgr.sv#L327-L328).

This wasn't being caught before because SW was either reading fast enough / only in cases before any subsequent FSM ticks, and/or was just discarding the incorrect `IDLE` state.