### PR TITLE
`flashgen.py`: allow loading arbitrary binaries into flash images using `--otdesc`

### DIFF
--- a/docs/opentitan/flashgen.md
+++ b/docs/opentitan/flashgen.md
@@ -77,13 +77,13 @@ matching signed binary files to help with debugging.
   may also be hardcoded in the ROM_EXT application. Changing the default offset may cause the
   ROM_EXT to fail to load the BL0 application.
 
-* `-t binfile@address[:elfile]` specify a binary file to store into the data partition of the flash.
+* `-t binfile@address` specify a binary file to store into the data partition of the flash.
   This is a compatibility option introduced to support the original `opentitantool image assemble`
-  syntax. In this mode, the file kind and the destination flash bank are guessed from the specified
-  address. The address should be specified in hexadecimal format. It is possible to specify an
-  matching ELF file by appending its path after a column separator following the address value. This
-  option may be repeated to specify multiple files such as the ROM EXT and a bootloader for example.
-  This option is mutually exclusive with `-b`, `-B`, `-x`, `-X` and `-a`.
+  syntax. The provided address should be specified in hexadecimal format. Currently, it is not
+  possible to specify a matching ELF file as the flash debug trailer format is hardcoded to only
+  support ROM EXT and bootloader binaries in both banks, and does not support arbitrary ELFs.
+  This option may be repeated to specify multiple files such as the ROM EXT and a bootloader for
+  example. This option is mutually exclusive with `-b`, `-B`, `-x`, `-X` and `-a`.
 
 * `-X elf` specify an alternative path to the ROM_EXT ELF file. If not specified, the ELF path file
   is reconstructed from the specified binary file (from the same directory). The ELF file is only

--- a/python/qemu/ot/eflash/gen.py
+++ b/python/qemu/ot/eflash/gen.py
@@ -359,13 +359,11 @@ class FlashGen:
         self._store_debug_info(ename, elfpath)
 
     def store_ot_files(self, otdescs: list[str]) -> None:
-        for dpos, otdesc in enumerate(otdescs, start=1):
-            parts = otdesc.rsplit(':', 1)
-            if len(parts) > 1:
-                otdesc = parts[0]
-                elf_filename = parts[1]
-            else:
-                elf_filename = None
+        for otdesc in otdescs:
+            # @TODO: add back support for ELFs for convenience debug symbols
+            # when the flash debug trailer format is changed to support
+            # arbitrary numbers (and locations) of ELFs, which is also
+            # needed due to mutable flash.
             parts = otdesc.split('@', 1)
             if len(parts) < 2:
                 raise ValueError('Missing address in OT descriptor')
@@ -376,16 +374,18 @@ class FlashGen:
                 address = int(parts[1], 16)
             except ValueError as exc:
                 raise ValueError('Invalid address in OT descriptor') from exc
-            bank = address // self.BYTES_PER_BANK
-            address %= self.BYTES_PER_BANK
-            kind = 'rom_ext' if address < self.CHIP_ROM_EXT_SIZE_MAX else \
-                'bootloader'
-            self._log.info(
-                'Handling file #%d as %s @ 0x%x in bank %d with%s ELF',
-                dpos, kind, address, bank, '' if elf_filename else 'out')
+            max_offset = self.NUM_BANKS * self.BYTES_PER_BANK
+            if not 0 <= address < max_offset:
+                raise ValueError(f'Invalid address 0x{address:x} for bin '
+                                 f'{basename(bin_filename)}')
             with open(bin_filename, 'rb') as bfp:
-                # func decode should never fail, so no error handling here
-                getattr(self, f'store_{kind}')(bank, bfp, elf_filename)
+                data = bfp.read()
+            address_end = address + len(data)
+            if not 0 <= address_end <= max_offset:
+                raise ValueError(f'Binary {basename(bin_filename)} at '
+                                 f'0x{address:x}:0x{address_end:x} does not '
+                                 f'fit in flash size 0x{max_offset:x}')
+            self._write(self._header_size + address, data)
 
     def _compare_bin_elf(self, bindesc: RuntimeDescriptor, elfpath: str) \
             -> Optional[bool]:


### PR DESCRIPTION
Currently, the `--otdesc` option accepts an address for a binary, and then attempts to guess whether the binary is a ROM_EXT or a bootloader file, loading it at hard-coded offsets with relevant size and ELF checks etc. This is not hugely useful and primarily exists for compatibility with the `opentitantool image assemble` format (it is unclear whether anything still uses this, I don't think so though).

Currently, `opentitantool image assemble` is being used within OpenTitan to construct an image spanning both flash banks; it is more useful in `flashgen.py` to be able to place binaries (or any data) of any size at any arbitrary location in flash, so long as it does not exceed the flash capacity.  This commit modifies this option to mean "place this data at this location, without care for what it is".

For now, use of ELFs for debug symbol support is dropped from the `--otdesc` option, because binaries can be loaded which are not ROM_EXTs or bl0s as defined in the flash format (e.g. further boot stages). The flash format currently hardcodes ELFs to only support ROM_EXT and bl0 ELFs in specific locations (also see https://github.com/lowRISC/qemu/issues/193). An ideal solution to this issue would update the flash format in the future to support an arbitrary number of convenience debugging ELFs, at which point this option can be added back, but for now this PR drops support for this option (for `--otdesc` only, not for `--exec` and `--boot`) to prioritise debugging of ROM_EXT tests on Earlgrey.

*Aside*: in the future it might be nice to extend this to also support placing binaries in INFO pages to essentially support splicing of flash info pages.