### PR TITLE
`ot_vmapper`: Fix range sort comparator logic

### DIFF
--- a/hw/opentitan/ot_vmapper.c
+++ b/hw/opentitan/ot_vmapper.c
@@ -113,10 +113,13 @@ static gint ot_vmapper_compare(gconstpointer a, gconstpointer b)
     const OtRegionRange *ra = (const OtRegionRange *)a;
     const OtRegionRange *rb = (const OtRegionRange *)b;
 
-    return (gint)((ra->start == rb->start) ?
-                      ((ra->end == rb->end) ? (ra->prio - rb->prio) :
-                                              (ra->end - rb->end)) :
-                      (ra->start - rb->start));
+    if (ra->start == rb->start) {
+        if (ra->end == rb->end) {
+            return (gint)ra->prio - (gint)rb->prio;
+        }
+        return (ra->end < rb->end) ? -1 : 1;
+    }
+    return (ra->start < rb->start) ? -1 : 1;
 }
 
 /*


### PR DESCRIPTION
This PR fixes the comparator logic for sorting address ranges as used by the vmapper device.

The current logic uses the difference between the `start` and `end` addresses of each range, which are stored as `uint32_t` values (which is correct, as virtual address ranges can cover any valid 32 bit address). By subtracting the addresses in unsigned arithmetic we will underflow in the case that the first address is smaller than the second.

Furthermore, the conversion to a signed `gint` (`int`) means that for large address differences (e.g. consider a region starts at `0x00000000` and another at `0x80000001` or higher) the result will when cast overflow the 32-bit signed domain to become a negative value.

Replace this logic with comparisons that return simple unit sign values. This now performs the intended sorting without risking overflow.
