### PR TITLE
`ot_flash`: Re-enable disabled flash MMIO region on reset

### DIFF
--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -3175,6 +3175,8 @@ static void ot_flash_reset_enter(Object *obj, ResetType type)
     OtFlashClass *c = OT_FLASH_GET_CLASS(obj);
     OtFlashState *s = OT_FLASH(obj);
 
+    trace_ot_flash_reset(s->ot_id, "enter");
+
     if (c->parent_phases.enter) {
         c->parent_phases.enter(obj, type);
     }
@@ -3292,6 +3294,8 @@ static void ot_flash_reset_exit(Object *obj, ResetType type)
 {
     OtFlashClass *c = OT_FLASH_GET_CLASS(obj);
     OtFlashState *s = OT_FLASH(obj);
+
+    trace_ot_flash_reset(s->ot_id, "exit");
 
     if (c->parent_phases.exit) {
         c->parent_phases.exit(obj, type);

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -3268,6 +3268,9 @@ static void ot_flash_reset_enter(Object *obj, ResetType type)
 
     s->csrs[R_CSR0_REGWEN] = 0x1u;
 
+    /* restore flash memory region enablement if previously disabled */
+    memory_region_set_enabled(&s->mmio.mem, true);
+
     s->latched_alerts = 0u;
 
     s->lc_broadcast.incoming_signal_bm = 0u;

--- a/hw/opentitan/trace-events
+++ b/hw/opentitan/trace-events
@@ -215,6 +215,7 @@ ot_flash_op_prog(const char* id, unsigned op_addr, unsigned count, unsigned rema
 ot_flash_op_start(const char* id, const char *op, bool hw) "%s: %s (hw=%u)"
 ot_flash_prog_word(const char* id, bool info_part, unsigned word_addr, uint32_t word) "%s: info_part %u word_addr %u word %u"
 ot_flash_read_keymgr_seed(const char* id, unsigned page, bool success) "%s: %u: %u"
+ot_flash_reset(const char *id, const char *phase) "%s: %s"
 ot_flash_reset_fifo(const char* id, const char *name) "%s: %s"
 ot_flash_set_error(const char* id, const char *op, bool hw, uint32_t err_code, uint32_t err_addr) "%s: %s (hw=%u): err=0x%08x at addr=0x%06x"
 ot_flash_update_alert(const char* id, int prev, int next) "%s: %d -> %d"


### PR DESCRIPTION
Although the `DIS` disablement register was being reset on reset, the flash `mmio.mem` memory region's enablement was not being reset. This caused some difficult to debug issues due to QEMU's non-determinism where resets could occur before or after SW disables the flash on ROM_EXT boot failures, essentially permanently locking Earlgrey out of its flash in some executions. Fix this and add a trace to make future debugging easier.
