### PR TITLE
`ot_vmapper`: fix setting destination address when splitting ranges

### DIFF
--- a/hw/opentitan/ot_vmapper.c
+++ b/hw/opentitan/ot_vmapper.c
@@ -429,8 +429,8 @@ static GList *ot_vmapper_range_discretize(OtVMapperState *s, GList *rglist)
                     OtRegionRange *right = g_new0(OtRegionRange, 1);
                     right->start = VMAP_RANGE(next)->end + 1u;
                     right->end = VMAP_RANGE(current)->end;
-                    right->dest =
-                        right->dest + right->start - VMAP_RANGE(current)->start;
+                    right->dest = VMAP_RANGE(current)->dest + right->start -
+                                  VMAP_RANGE(current)->start;
                     right->prio = VMAP_RANGE(current)->prio;
                     right->execute = VMAP_RANGE(current)->execute;
                     right->active = true;


### PR DESCRIPTION
When a smaller block of higher priority is carved out from bigger one (case a2), destination address was set as:

````c
right->dest = right->dest + right->start - VMAP_RANGE(current)->start;
````

While start offset was calculated correctly, destination base was always intialized as zeros due to right->dest being 0, as it wasn't touched before getting allocated via g_new0().
Current block destination address should be used as the base here.