### PR TITLE
`ot_keymgr`: Add property to disable flash seed check

### DIFF
--- a/docs/opentitan/earlgrey.md
+++ b/docs/opentitan/earlgrey.md
@@ -206,6 +206,10 @@ There are two modes to handle address remapping, with different limitations:
   whenever possible. To enable this legacy mode, set the `alias-mode` property to true:
   `-global ot-ibex_wrapper.alias-mode=true`
 
+### Keymgr
+
+See documentation in [`keymgr.md`](./keymgr.md).
+
 ### OTBN
 
 * `-global ot-otbn.logfile=<filename>` output OTBN execution message to the specified logfile. When

--- a/docs/opentitan/keymgr.md
+++ b/docs/opentitan/keymgr.md
@@ -1,0 +1,14 @@
+# OpenTitan Key Manager support
+
+## Properties
+
+- `-global ot-keymgr.disable-flash-seed-check=true` can be used to disable the
+data validity check in the Keymgr for loaded flash secrets (the owner and
+creator seed). This validity check ensures that the loaded key is not all-zero
+or all-one (and thus probably uninitialized). When emulating OpenTitan, it may
+be useful to be able to advance using uninitialized keys due to a lack of flash
+info splicing, to bypass the need to run through an entire provisioning flow.
+  - Note also that the fatal Keymgr alert caused by failing this check should
+  not appear for unprovisioned flash if flash scrambling is implemented (and
+  enabled). This is because the garbage unscrambled data that is read will not
+  pass this check.

--- a/hw/opentitan/ot_keymgr.c
+++ b/hw/opentitan/ot_keymgr.c
@@ -457,6 +457,7 @@ typedef struct OtKeyMgrState {
     DeviceState *key_sinks[KEYMGR_KEY_SINK_COUNT];
     char *seed_xstrs[KEYMGR_SEED_COUNT];
     bool use_default_entropy_seed; /* flag to seed PRNG with default seed */
+    bool disable_flash_seed_check; /* disable all-0/1 check for flash seeds */
 } OtKeyMgrState;
 
 struct OtKeyMgrClass {
@@ -1095,6 +1096,18 @@ ot_keymgr_kdf_append_flash_seed(OtKeyMgrState *s, OtFlashKeyMgrSecretType type,
     ot_keymgr_kdf_push_bytes(s, seed.secret, OT_FLASH_KEYMGR_SECRET_BYTES);
     bool data_valid =
         ot_keymgr_valid_data_check(seed.secret, OT_FLASH_KEYMGR_SECRET_BYTES);
+
+    /*
+     * Unprovisioned flash will not contain valid secrets, and will return all
+     * 1s (failing the validity check) if scrambling/ECCs are disabled. Using
+     * the `disable-flash-seed-check` property allows you to optionally bypass
+     * these errors for unprovisioned environments where flash info page
+     * splicing is not available.
+     */
+    if (!data_valid && s->disable_flash_seed_check) {
+        trace_ot_keymgr_bypass_failure(s->ot_id, seed_name);
+        data_valid = true;
+    }
     if (!seed.valid || !data_valid) {
         s->regs[R_DEBUG] |= debug_mask;
         s->op_state.valid_inputs = false;
@@ -2351,6 +2364,8 @@ static Property ot_keymgr_properties[] = {
                        seed_xstrs[KEYMGR_SEED_NONE]),
     DEFINE_PROP_BOOL("use-default-entropy-seed", OtKeyMgrState,
                      use_default_entropy_seed, false),
+    DEFINE_PROP_BOOL("disable-flash-seed-check", OtKeyMgrState,
+                     disable_flash_seed_check, false),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/opentitan/trace-events
+++ b/hw/opentitan/trace-events
@@ -280,6 +280,7 @@ ot_ibex_wrapper_update_exec(const char *id, uint32_t bm, bool esc_rx, bool halte
 
 # ot_keymgr.c
 ot_keymgr_advance(const char *id, const char *stage, int nstage, const char *cdi, int ncdi) "%s: [%s:%d], [%s:%d]"
+ot_keymgr_bypass_failure(const char *id, const char *what) "%s: bypass failure for %s due to enabled properties"
 ot_keymgr_change_main_fsm_state(const char *id, int line, const char *old, int nold, const char *new, int nnew) "%s: @ %d [%s:%d] -> [%s:%d]"
 ot_keymgr_change_op_status(const char *id, int line, const char *old, int nold, const char *new, int nnew) "%s: @ %d [%s:%d] -> [%s:%d]"
 ot_keymgr_change_working_state(const char *id, int line, const char *old, int nold, const char *new, int nnew) "%s: @ %d [%s:%d] -> [%s:%d]"


### PR DESCRIPTION
This PR introduces an optional property that provides a mechanism to disable the "all zero/one` data validity check when loading flash seeds as part of keymgr advancement.

The motivation is to support wider usage with unprovisioned flash information pages, which will not have these pages initialized and thus will fail keymgr advancement due to the current lack of flash scrambling.