### PR TITLE
[ot] scripts/opentitan: requirements.txt: redefine pylint version range

### DIFF
--- a/scripts/opentitan/requirements.txt
+++ b/scripts/opentitan/requirements.txt
@@ -1,5 +1,5 @@
 # Python requirements
-pylint>=3.3.3
+pylint>=3.3.3, <4.0
 pyyaml>=6
 hjson>=3.1
 pyelftools>=0.30


### PR DESCRIPTION
pylint 4.0 has been released and rule checking slightly differs, reporting new issues that were not detected with prior versions of this tool.

Reduce the accepted range of pylint versions so that existing code base is always checked against the same set of rules.