### PR TITLE
`hw/core`: loader.c: make generic loader image loadable at will

### DIFF
--- a/hw/core/loader.c
+++ b/hw/core/loader.c
@@ -1420,6 +1420,11 @@ int rom_check_and_register_reset(void)
     return 0;
 }
 
+void rom_load(void)
+{
+    rom_reset(NULL);
+}
+
 void rom_set_fw(FWCfgState *f)
 {
     fw_cfg = f;

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -29,6 +29,7 @@
 #include "hw/intc/sifive_plic.h"
 #include "hw/jtag/tap_ctrl.h"
 #include "hw/jtag/tap_ctrl_rbb.h"
+#include "hw/loader.h"
 #include "hw/misc/pulp_rv_dm.h"
 #include "hw/misc/unimp.h"
 #include "hw/opentitan/ot_address_space.h"
@@ -1694,6 +1695,8 @@ static void ot_dj_soc_reset_exit(Object *obj, ResetType type)
     if (c->parent_phases.exit) {
         c->parent_phases.exit(obj, type);
     }
+
+    rom_load();
 
     /* Kick off ROM checks and boot */
     object_property_set_bool(OBJECT(s->devices[OT_DJ_SOC_DEV_ROM_CTRL0]),

--- a/include/hw/loader.h
+++ b/include/hw/loader.h
@@ -389,4 +389,9 @@ typedef struct RomGap {
  */
 RomGap rom_find_largest_gap_between(hwaddr base, size_t size);
 
+/**
+ * rom_load: Load all registered ROMs
+ */
+void rom_load(void);
+
 #endif


### PR DESCRIPTION
Image file loaded with `-device loader,file=...` are copied back to their destination device when the generic QEMU reset feature is invoked.

As OpenTitan device use a specialized reset scheme, we may need to copy the so-called "ROM" images (as QEMU non-modifiable image, not related to OT ROM controller images) at will.

Add a public API to trigger this image-to-device copy since the default API is private.