### PR TITLE
`hw/riscv`: ot_darjeeling: add verilator machine property and clocks

### DIFF
--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -82,7 +82,8 @@
 /* ------------------------------------------------------------------------ */
 /* Forward Declarations */
 /* ------------------------------------------------------------------------ */
-
+static void ot_dj_soc_ast_configure(DeviceState *dev, const IbexDeviceDef *def,
+                                    DeviceState *parent);
 static void ot_dj_soc_dm_configure(DeviceState *dev, const IbexDeviceDef *def,
                                    DeviceState *parent);
 static void ot_dj_soc_hart_configure(DeviceState *dev, const IbexDeviceDef *def,
@@ -1420,12 +1421,11 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
     },
     [OT_DJ_SOC_DEV_AST] = {
         .type = TYPE_OT_AST_DJ,
+        .cfg = &ot_dj_soc_ast_configure,
         .memmap = MEMMAPENTRIES(
             { .base = 0x30480000u }
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("topclocks",
-                "main:1000000000,io:1000000000,aon:62500000"),
             IBEX_DEV_STRING_PROP("aonclocks", "aon")
         ),
     },
@@ -1520,6 +1520,26 @@ struct OtDjMachineState {
 /* ------------------------------------------------------------------------ */
 /* Device Configuration */
 /* ------------------------------------------------------------------------ */
+
+static void ot_dj_soc_ast_configure(DeviceState *dev, const IbexDeviceDef *def,
+                                    DeviceState *parent)
+{
+    (void)def;
+    (void)parent;
+
+    bool verilator_mode =
+        object_property_get_bool(qdev_get_machine(), "verilator", NULL);
+    const char *clock_cfg;
+    if (!verilator_mode) {
+        /* Defaults for Darjeeling HW */
+        clock_cfg = "main:1000000000,io:1000000000,aon:62500000";
+    } else {
+        /* From verilator model */
+        clock_cfg = "main:500000,io:500000,aon:125000";
+    }
+
+    qdev_prop_set_string(dev, "topclocks", clock_cfg);
+}
 
 static void ot_dj_soc_dm_configure(DeviceState *dev, const IbexDeviceDef *def,
                                    DeviceState *parent)

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1514,6 +1514,7 @@ struct OtDjMachineState {
 
     bool no_epmp_cfg;
     bool ignore_elf_entry;
+    bool verilator;
 };
 
 /* ------------------------------------------------------------------------ */
@@ -1994,6 +1995,22 @@ ot_dj_machine_set_ignore_elf_entry(Object *obj, bool value, Error **errp)
     s->ignore_elf_entry = value;
 }
 
+static bool ot_dj_machine_get_verilator(Object *obj, Error **errp)
+{
+    OtDjMachineState *s = RISCV_OT_DJ_MACHINE(obj);
+    (void)errp;
+
+    return s->verilator;
+}
+
+static void ot_dj_machine_set_verilator(Object *obj, bool value, Error **errp)
+{
+    OtDjMachineState *s = RISCV_OT_DJ_MACHINE(obj);
+    (void)errp;
+
+    s->verilator = value;
+}
+
 static ResettableState *ot_dj_machine_get_reset_state(Object *obj)
 {
     OtDjMachineState *s = RISCV_OT_DJ_MACHINE(obj);
@@ -2032,6 +2049,9 @@ static void ot_dj_machine_instance_init(Object *obj)
                              &ot_dj_machine_set_ignore_elf_entry);
     object_property_set_description(obj, "ignore-elf-entry",
                                     "Do not set vCPU PC with ELF entry point");
+    object_property_add_bool(obj, "verilator", &ot_dj_machine_get_verilator,
+                             &ot_dj_machine_set_verilator);
+    object_property_set_description(obj, "verilator", "Use Verilator clocks");
 }
 
 static void ot_dj_machine_init(MachineState *state)

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -948,7 +948,6 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
             OT_EG_SOC_DEVLINK("clock-src", AST)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            /* topclocks property overridden in ot_eg_soc_ast_configure */
             IBEX_DEV_STRING_PROP("topclocks", "main:500,io:480,usb:240,aon:1"),
             IBEX_DEV_STRING_PROP("refclock", "aon"),
             IBEX_DEV_STRING_PROP("subclocks",


### PR DESCRIPTION
This is a sibling implementation of what is already supported for the EarlGrey machine