### PR TITLE
`ot_flash`: Improve docs & use IO region for host reads by default

### DIFF
--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -79,7 +79,7 @@
  * which will speed up flash host reads via TB caching but also mean that data
  * mutation after an initial instruction fetch could lead to invalid execution.
  */
-#define DATA_PART_USE_IO_OPS 0
+#define DATA_PART_USE_IO_OPS 1
 
 /* set to log hart GPR on flash data access */
 #define LOG_GPR_ON_FLASH_DATA_ACCESS 0

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -815,13 +815,6 @@ typedef struct {
 } OtFlashBackendHeader;
 
 typedef struct {
-    uint32_t *data;
-    uint32_t capacity;
-    uint32_t head;
-    uint32_t num;
-} OtFlashFifo;
-
-typedef struct {
     QEMUTimer *timer;
     uint16_t incoming_signal_bm; /* each bit tells if signal needs handling */
     uint16_t incoming_level_bm; /* level (0/1) of the incoming signals */

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -68,7 +68,17 @@
 #include "sysemu/block-backend.h"
 #include "trace.h"
 
-/* set to use I/O to access the flash partition */
+/*
+ * Set to use I/O to access the flash partition. This will define the flash
+ * memory data partition as a device-mapped MMIO region in the guest's
+ * physical address space. This means that QEMU's TCG will not cache fetches
+ * from XIP flash memory in its TBs, allowing correct execution of (self-)
+ * mutable code in flash.
+ *
+ * Setting this to 0 will instead use a read-only RAM backend emulating a ROM,
+ * which will speed up flash host reads via TB caching but also mean that data
+ * mutation after an initial instruction fetch could lead to invalid execution.
+ */
 #define DATA_PART_USE_IO_OPS 0
 
 /* set to log hart GPR on flash data access */
@@ -3106,12 +3116,21 @@ static uint64_t ot_flash_mem_read(void *opaque, hwaddr addr, unsigned size)
     OtFlashState *s = opaque;
     uint32_t val32;
 
+    /*
+     * for correct XIP flash, execution disablement is abstracted & handled via
+     * the `ot_vmapper` in `ot_flash_update_exec` instead.
+     */
     if (ot_flash_is_disabled(s)) {
         qemu_log_mask(LOG_GUEST_ERROR, "%s: %s: flash has been disabled\n",
                       __func__, s->ot_id);
         return 0u;
     }
 
+    /*
+     * System hosts can only directly read from the data partition, and do not
+     * have access to any information partitions. They are also not subject
+     * to memory protection, which only applies to the protocol controller.
+     */
     if (addr < s->flash.bank_count * s->flash.data_size) {
         val32 = s->flash.data[addr >> 2u];
         unsigned offset = (unsigned)(addr & 0x3u);
@@ -3125,7 +3144,8 @@ static uint64_t ot_flash_mem_read(void *opaque, hwaddr addr, unsigned size)
                 RV_GPR_PC | RV_GPR_T0 | RV_GPR_T1 | RV_GPR_T2 | RV_GPR_A0 |
                 RV_GPR_A1 | RV_GPR_A2);
 #endif /* LOG_GPR_ON_FLASH_DATA_ACCESS */
-        trace_ot_flash_mem_read_out(s->ot_id, (uint32_t)addr, size, val32, pc);
+        trace_ot_flash_mem_host_read_out(s->ot_id, (uint32_t)addr, size, val32,
+                                         pc);
     } else {
         uint32_t pc = ibex_get_current_pc();
         qemu_log_mask(LOG_GUEST_ERROR,

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -3125,7 +3125,7 @@ static uint64_t ot_flash_mem_read(void *opaque, hwaddr addr, unsigned size)
                 RV_GPR_PC | RV_GPR_T0 | RV_GPR_T1 | RV_GPR_T2 | RV_GPR_A0 |
                 RV_GPR_A1 | RV_GPR_A2);
 #endif /* LOG_GPR_ON_FLASH_DATA_ACCESS */
-        trace_ot_flash_mem_read_out((uint32_t)addr, size, val32, pc);
+        trace_ot_flash_mem_read_out(s->ot_id, (uint32_t)addr, size, val32, pc);
     } else {
         uint32_t pc = ibex_get_current_pc();
         qemu_log_mask(LOG_GUEST_ERROR,

--- a/hw/opentitan/trace-events
+++ b/hw/opentitan/trace-events
@@ -207,7 +207,7 @@ ot_flash_io_read_out(const char *id, uint32_t addr, const char * regname, uint32
 ot_flash_io_write(const char *id, uint32_t addr, const char * regname, uint32_t val, uint32_t pc) "%s: addr=0x%02x (%s), val=0x%x, pc=0x%x"
 ot_flash_irqs(const char *id, uint32_t active, uint32_t mask, uint32_t eff) "%s: act:0x%08x msk:0x%08x eff:0x%08x"
 ot_flash_lc_broadcast(const char* id, unsigned sig, bool level) "%s: bcast %u, level %u"
-ot_flash_mem_read_out(const char* id, uint32_t addr, unsigned size, uint32_t val, uint32_t pc) "%s: addr=0x%02x (%u), val=0x%08x, pc=0x%x"
+ot_flash_mem_host_read_out(const char* id, uint32_t addr, unsigned size, uint32_t val, uint32_t pc) "%s: addr=0x%02x (%u), val=0x%08x, pc=0x%x"
 ot_flash_merge_info_qual(const char* id, unsigned bank, unsigned infosel, unsigned page, uint8_t reg_cfg, uint8_t qual, uint8_t merged) "%s: bank:%u infosel:%u page:%u, reg_cfg:0x%02x & qual:0x%02x = 0x%02x"
 ot_flash_op_complete(const char* id, const char *op, bool hw, bool success) "%s: %s (hw=%u): %u"
 ot_flash_op_execute(const char* id, const char *op, bool hw) "%s: %s (hw=%u)"


### PR DESCRIPTION
The main change is in the last commit, the rest are small fixes and improving documentation. By using a device-mapped IO MemoryRegion by default, host flash reads will not be cached in the TCG as regular RAM memory reads would be, which can cause issues as Earlgrey's flash is mutable and execute-in-place (XIP).

In Earlgrey it is quite common to bootstrap different code into flash; if we execute from some code and then later want to bootstrap over it the wrong instructions may be executed, as the TCG isn't currently aware that the region is dirty and it should flush relevant parts of its TB. By switching to use an IO region by default, this case is properly handled.

See the commit messages / comments for more details.