### PR TITLE
`tools`: autoreg.py: add initial handling of compact multireg

### DIFF
--- a/scripts/opentitan/autoreg.py
+++ b/scripts/opentitan/autoreg.py
@@ -1070,10 +1070,16 @@ class BmTestAutoReg(AutoReg):
                 if flds and (len(flds) > 1 or flds[0].width != self._regwidth):
                     bitfields[reg.name] = reg.fields
         reg = None
+        address = 0
+        rsvcnt = 0
         for reg in self._registers:
+            if reg.address > address:
+                rsvcnt += 1
+                self._generate_reserved_register(address, f'_reserved{rsvcnt}',
+                                                 nibcount, tfp)
             self._generate_register(reg, shared_fields, nibcount, reg.count,
                                     tfp)
-        address = reg.address + (reg.count * self._regwidth) // 8 if reg else 0
+            address = reg.address + (reg.count * self._regwidth) // 8
         print(f'        (0x{address:0{nibcount}x} => @END),', file=tfp)
         print('    }\n}\n', file=tfp)
         print(f'register_bitfields! [u{self._regwidth},', file=tfp)
@@ -1111,7 +1117,10 @@ class BmTestAutoReg(AutoReg):
             print(f'        (0x{reg.address:0{nibcount}x} => '
                   f'{reg.name.lower()}: '
                   f'{regtype}<u{self._regwidth}{regdesc}>),', file=tfp)
-        self._log.warning('Reg: %s', reg)
+
+    def _generate_reserved_register(self, address: int, name: str,
+                                    nibcount: int, tfp: TextIO):
+        print(f'        (0x{address:0{nibcount}x} => {name},', file=tfp)
 
 
 def main():

--- a/scripts/opentitan/autoreg.py
+++ b/scripts/opentitan/autoreg.py
@@ -156,10 +156,30 @@ class AutoReg:
                 continue
             if 'multireg' in item:
                 item = item['multireg']
+                compact = item.get('compact', True)
                 reg = self._parse_register(address, item)
                 count = safe_eval(item['count'], self._parameters)
-                reg = reg._replace(count=count)
-                regnames.add((f'{reg.name}_{ix}' for ix in range(count)))
+                if compact:
+                    # single register with multiple fields with the same prefix
+                    if len(reg.fields) > 1:
+                        # not sure if the following case may exists, anyway for
+                        # now it is not supported
+                        raise NotImplementedError(f'Too many compact fields for'
+                                                  f' {reg.name}')
+                    field = reg.fields[0]
+                    if count <= self._regwidth:
+                        bitcount = min(count, self._regwidth)
+                        reg = reg._replace(fields=[
+                            field._replace(name=f'{field.name}_{pos}', offset=pos)
+                            for pos in range(bitcount)
+                        ])
+                    else:
+                        reg = reg._replace(fields=[])
+                    count = (count + self._regwidth - 1) // self._regwidth
+                if count > 1:
+                    # multiple registers with the same name prefix
+                    reg = reg._replace(count=count)
+                    regnames.add((f'{reg.name}_{ix}' for ix in range(count)))
                 registers.append(reg)
                 address += addr_inc * count
                 continue


### PR DESCRIPTION
Depending on an optional `compact` boolean, multireg can either be generated as multiple registers or multiple fields.

Ex with a multireg with `count: 3`

```h
REG32(REGISTER_0, 0x00)
    SHARED_FIELD(REGISTER_FIELD, 0u, 1u)
REG32(REGISTER_1, 0x04)
REG32(REGISTER_2, 0x04)
```
or
```h
REG32(REGISTER, 0x00)
    FIELD(REGISTER, FIELD_0, 0u, 1u)
    FIELD(REGISTER, FIELD_1, 1u, 1u)
    FIELD(REGISTER, FIELD_2, 2u, 1u)
```
