### PR TITLE
`sifive_plic`: fix an old regression with lowered IRQs

### DIFF
--- a/hw/intc/sifive_plic.c
+++ b/hw/intc/sifive_plic.c
@@ -385,10 +385,12 @@ static void sifive_plic_irq_request(void *opaque, int irq, int level)
         if (level && !sifive_plic_get_level(s, irq)) {
             sifive_plic_set_pending(s, irq, true);
         }
+        sifive_plic_set_level(s, irq, !!level);
     } else {
-        sifive_plic_set_pending(s, irq, level > 0);
+        if (level > 0) {
+            sifive_plic_set_pending(s, irq, true);
+        }
     }
-    sifive_plic_set_level(s, irq, !!level);
     sifive_plic_update(s);
 }
 


### PR DESCRIPTION
This led to lose any interrupt a device had raised then lowered before the PLIC got claimed.

Upstream commit a84be2baa9 has been overridden by d5fbf92a3, which contains the invalid commit.