### PR TITLE
`ot_otp`: Add scrambling on DAI writes to secret partitions + REGWEN fixes

### DIFF
--- a/hw/opentitan/ot_otp_dj.c
+++ b/hw/opentitan/ot_otp_dj.c
@@ -2058,6 +2058,21 @@ static int ot_otp_dj_dai_write_u64(OtOTPDjState *s, unsigned address)
     uint32_t lo = s->regs[R_DIRECT_ACCESS_WDATA_0];
     uint32_t hi = s->regs[R_DIRECT_ACCESS_WDATA_1];
 
+    unsigned part_ix = (unsigned)s->dai->partition;
+    bool is_secret = ot_otp_dj_is_secret(part_ix);
+    bool is_zer = ot_otp_dj_is_part_zer_offset(part_ix, address);
+
+    if (is_secret && !is_zer) {
+        const uint8_t *scrambling_key = s->otp_scramble_keys[part_ix];
+        uint64_t data = ((uint64_t)hi << 32u) | lo;
+        g_assert(scrambling_key);
+        OtPresentState *ps = ot_present_new();
+        ot_present_init(ps, scrambling_key);
+        ot_present_encrypt(ps, data, &data);
+        lo = (uint32_t)data;
+        hi = (uint32_t)(data >> 32u);
+    }
+
     if ((dst_lo & ~lo) || (dst_hi & ~hi)) {
         qemu_log_mask(LOG_GUEST_ERROR, "%s: %s: Cannot clear OTP bits\n",
                       __func__, s->ot_id);

--- a/hw/opentitan/ot_otp_dj.c
+++ b/hw/opentitan/ot_otp_dj.c
@@ -2486,6 +2486,8 @@ static uint64_t ot_otp_dj_reg_read(void *opaque, hwaddr addr, unsigned size)
     case R_DIRECT_ACCESS_RDATA_1:
     case R_DIRECT_ACCESS_ADDRESS:
     case R_VENDOR_TEST_READ_LOCK ... R_ROM_PATCH_READ_LOCK:
+    case R_CHECK_TRIGGER_REGWEN:
+    case R_CHECK_REGWEN:
         val32 = s->regs[reg];
         break;
     case R_STATUS:
@@ -2497,16 +2499,16 @@ static uint64_t ot_otp_dj_reg_read(void *opaque, hwaddr addr, unsigned size)
         break;
     /* NOLINTNEXTLINE */
     case R_DIRECT_ACCESS_CMD:
+    case R_CHECK_TRIGGER:
         val32 = 0; /* R0W1C */
         break;
-    case R_CHECK_TRIGGER_REGWEN:
-    case R_CHECK_TRIGGER:
-    case R_CHECK_REGWEN:
     case R_CHECK_TIMEOUT:
     case R_INTEGRITY_CHECK_PERIOD:
     case R_CONSISTENCY_CHECK_PERIOD:
-        /* @todo not yet implemented */
-        val32 = 0;
+        /* @todo: not yet implemented, but these are R/W registers */
+        qemu_log_mask(LOG_UNIMP, "%s: %s: %s is not supported\n", __func__,
+                      s->ot_id, REG_NAME(reg));
+        val32 = s->regs[reg];
         break;
     case R_VENDOR_TEST_DIGEST_0 ... R_SECRET3_DIGEST_1:
         /*
@@ -2644,8 +2646,14 @@ static void ot_otp_dj_reg_write(void *opaque, hwaddr addr, uint64_t value,
         s->regs[reg] &= val32; /* RW0C */
         break;
     case R_CHECK_TRIGGER_REGWEN:
-    case R_CHECK_TRIGGER:
+        val32 &= R_CHECK_TRIGGER_REGWEN_REGWEN_MASK;
+        s->regs[reg] &= val32; /* RW0C */
+        break;
     case R_CHECK_REGWEN:
+        val32 &= R_CHECK_REGWEN_REGWEN_MASK;
+        s->regs[reg] &= val32; /* RW0C */
+        break;
+    case R_CHECK_TRIGGER:
     case R_CHECK_TIMEOUT:
     case R_INTEGRITY_CHECK_PERIOD:
     case R_CONSISTENCY_CHECK_PERIOD:

--- a/hw/opentitan/ot_otp_dj.c
+++ b/hw/opentitan/ot_otp_dj.c
@@ -2509,8 +2509,10 @@ static uint64_t ot_otp_dj_reg_read(void *opaque, hwaddr addr, unsigned size)
         val32 = ot_otp_dj_get_status(s);
         break;
     case R_DIRECT_ACCESS_REGWEN:
-        val32 = FIELD_DP32(0, DIRECT_ACCESS_REGWEN, REGWEN,
-                           (uint32_t)!ot_otp_dj_dai_is_busy(s));
+        /* disabled either if SW locked, or if DAI is busy. */
+        val32 = s->regs[reg];
+        val32 &= FIELD_DP32(0u, DIRECT_ACCESS_REGWEN, REGWEN,
+                            (uint32_t)!ot_otp_dj_dai_is_busy(s));
         break;
     /* NOLINTNEXTLINE */
     case R_DIRECT_ACCESS_CMD:
@@ -2606,7 +2608,6 @@ static void ot_otp_dj_reg_write(void *opaque, hwaddr addr, uint64_t value,
         break;
     case R_STATUS:
     case R_ERR_CODE_0 ... R_ERR_CODE_23:
-    case R_DIRECT_ACCESS_REGWEN:
     case R_DIRECT_ACCESS_RDATA_0:
     case R_DIRECT_ACCESS_RDATA_1:
     case R_VENDOR_TEST_DIGEST_0 ... R_SECRET3_DIGEST_1:
@@ -2638,6 +2639,10 @@ static void ot_otp_dj_reg_write(void *opaque, hwaddr addr, uint64_t value,
         val32 &= ALERT_WMASK;
         s->regs[reg] = val32;
         ot_otp_dj_update_alerts(s);
+        break;
+    case R_DIRECT_ACCESS_REGWEN:
+        val32 &= R_DIRECT_ACCESS_REGWEN_REGWEN_MASK;
+        s->regs[reg] &= val32; /* RW0C */
         break;
     case R_DIRECT_ACCESS_CMD:
         if (FIELD_EX32(val32, DIRECT_ACCESS_CMD, RD)) {

--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -1939,6 +1939,20 @@ static int ot_otp_eg_dai_write_u64(OtOTPEgState *s, unsigned address)
     uint32_t lo = s->regs[R_DIRECT_ACCESS_WDATA_0];
     uint32_t hi = s->regs[R_DIRECT_ACCESS_WDATA_1];
 
+    unsigned part_ix = (unsigned)s->dai->partition;
+    bool is_secret = ot_otp_eg_is_secret(part_ix);
+
+    if (is_secret) {
+        const uint8_t *scrambling_key = s->otp_scramble_keys[part_ix];
+        uint64_t data = ((uint64_t)hi << 32u) | lo;
+        g_assert(scrambling_key);
+        OtPresentState *ps = ot_present_new();
+        ot_present_init(ps, scrambling_key);
+        ot_present_encrypt(ps, data, &data);
+        lo = (uint32_t)data;
+        hi = (uint32_t)(data >> 32u);
+    }
+
     if ((dst_lo & ~lo) || (dst_hi & ~hi)) {
         qemu_log_mask(LOG_GUEST_ERROR, "%s: %s: Cannot clear OTP bits\n",
                       __func__, s->ot_id);

--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -2367,6 +2367,8 @@ static uint64_t ot_otp_eg_reg_read(void *opaque, hwaddr addr, unsigned size)
     case R_DIRECT_ACCESS_RDATA_1:
     case R_DIRECT_ACCESS_ADDRESS:
     case R_VENDOR_TEST_READ_LOCK ... R_ROT_CREATOR_AUTH_STATE_READ_LOCK:
+    case R_CHECK_TRIGGER_REGWEN:
+    case R_CHECK_REGWEN:
         val32 = s->regs[reg];
         break;
     case R_STATUS:
@@ -2378,16 +2380,16 @@ static uint64_t ot_otp_eg_reg_read(void *opaque, hwaddr addr, unsigned size)
         break;
     /* NOLINTNEXTLINE */
     case R_DIRECT_ACCESS_CMD:
+    case R_CHECK_TRIGGER:
         val32 = 0; /* R0W1C */
         break;
-    case R_CHECK_TRIGGER_REGWEN:
-    case R_CHECK_TRIGGER:
-    case R_CHECK_REGWEN:
     case R_CHECK_TIMEOUT:
     case R_INTEGRITY_CHECK_PERIOD:
     case R_CONSISTENCY_CHECK_PERIOD:
-        /* TODO: not yet implemented */
-        val32 = 0;
+        /* @todo: not yet implemented, but these are R/W registers */
+        qemu_log_mask(LOG_UNIMP, "%s: %s: %s is not supported\n", __func__,
+                      s->ot_id, REG_NAME(reg));
+        val32 = s->regs[reg];
         break;
     case R_VENDOR_TEST_DIGEST_0 ... R_SECRET2_DIGEST_1:
         /*
@@ -2525,8 +2527,14 @@ static void ot_otp_eg_reg_write(void *opaque, hwaddr addr, uint64_t value,
         s->regs[reg] &= val32; /* RW0C */
         break;
     case R_CHECK_TRIGGER_REGWEN:
-    case R_CHECK_TRIGGER:
+        val32 &= R_CHECK_TRIGGER_REGWEN_REGWEN_MASK;
+        s->regs[reg] &= val32; /* RW0C */
+        break;
     case R_CHECK_REGWEN:
+        val32 &= R_CHECK_REGWEN_REGWEN_MASK;
+        s->regs[reg] &= val32; /* RW0C */
+        break;
+    case R_CHECK_TRIGGER:
     case R_CHECK_TIMEOUT:
     case R_INTEGRITY_CHECK_PERIOD:
     case R_CONSISTENCY_CHECK_PERIOD:

--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -2389,8 +2389,10 @@ static uint64_t ot_otp_eg_reg_read(void *opaque, hwaddr addr, unsigned size)
         val32 = ot_otp_eg_get_status(s);
         break;
     case R_DIRECT_ACCESS_REGWEN:
-        val32 = FIELD_DP32(0, DIRECT_ACCESS_REGWEN, REGWEN,
-                           (uint32_t)!ot_otp_eg_dai_is_busy(s));
+        /* disabled either if SW locked, or if DAI is busy. */
+        val32 = s->regs[reg];
+        val32 &= FIELD_DP32(0u, DIRECT_ACCESS_REGWEN, REGWEN,
+                            (uint32_t)!ot_otp_eg_dai_is_busy(s));
         break;
     /* NOLINTNEXTLINE */
     case R_DIRECT_ACCESS_CMD:
@@ -2486,7 +2488,6 @@ static void ot_otp_eg_reg_write(void *opaque, hwaddr addr, uint64_t value,
         break;
     case R_STATUS:
     case R_ERR_CODE_0 ... R_ERR_CODE_12:
-    case R_DIRECT_ACCESS_REGWEN:
     case R_DIRECT_ACCESS_RDATA_0:
     case R_DIRECT_ACCESS_RDATA_1:
     case R_VENDOR_TEST_DIGEST_0 ... R_SECRET2_DIGEST_1:
@@ -2518,6 +2519,10 @@ static void ot_otp_eg_reg_write(void *opaque, hwaddr addr, uint64_t value,
         val32 &= ALERT_WMASK;
         s->regs[reg] = val32;
         ot_otp_eg_update_alerts(s);
+        break;
+    case R_DIRECT_ACCESS_REGWEN:
+        val32 &= R_DIRECT_ACCESS_REGWEN_REGWEN_MASK;
+        s->regs[reg] &= val32; /* RW0C */
         break;
     case R_DIRECT_ACCESS_CMD:
         if (FIELD_EX32(val32, DIRECT_ACCESS_CMD, RD)) {

--- a/tests/opentitan/data/earlgrey-tests.txt
+++ b/tests/opentitan/data/earlgrey-tests.txt
@@ -485,6 +485,8 @@ pass: //sw/device/tests:kmac_mode_kmac_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:kmac_mode_kmac_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:kmac_smoketest_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:kmac_smoketest_sim_qemu_sival_rom_ext
+pass: //sw/device/tests:lc_ctrl_otp_hw_cfg0_test_sim_qemu_rom_with_fake_keys
+pass: //sw/device/tests:lc_ctrl_otp_hw_cfg0_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:otbn_ecdsa_op_irq_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:otbn_ecdsa_op_irq_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:otbn_irq_test_sim_qemu_rom_with_fake_keys
@@ -497,6 +499,7 @@ pass: //sw/device/tests:otbn_rsa_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:otbn_rsa_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:otbn_smoketest_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:otbn_smoketest_sim_qemu_sival_rom_ext
+pass: //sw/device/tests:otp_ctrl_descrambling_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:plic_sw_irq_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:plic_sw_irq_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:pmp_smoketest_napot_sim_qemu_rom_with_fake_keys
@@ -541,6 +544,8 @@ pass: //sw/device/tests:uart_smoketest_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:uart_smoketest_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:usbdev_mem_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:usbdev_mem_test_sim_qemu_sival_rom_ext
+pass: //sw/device/tests:usbdev_vbus_test_sim_qemu_rom_with_fake_keys
+pass: //sw/device/tests:usbdev_vbus_test_sim_qemu_sival_rom_ext
 pass: //third_party/coremark/top_earlgrey:coremark_test_sim_qemu_rom_with_fake_keys
 pass: //third_party/coremark/top_earlgrey:coremark_test_sim_qemu_sival_rom_ext
 pass: //third_party/riscv-compliance:C-ADDI16SP_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
While we have scrambling on reads from secret partitions, to properly support provisioning flows we will need to be able to scramble when programming these secret partitions via DAI writes. Add support for these to both Earlgrey and Darjeeling.

As part of testing this, I also found that the two check REGWEN registers were unimplemented, which were being checked by some SW test utilities. While the check functionality is still unimplemented, writes/reads of these REGWENs are now implemented in both Earlgrey and Darjeeling, and the access permissions of some of these registers are fixed. This should be sufficient now to support the `lc_ctrl_otp_hw_cfg0_test`, as well as the `otp_ctrl_smoketest` when QEMU is enabled for that test upstream.

There was no nice existing test for this feature in OpenTitan except in DV environments, so I threw together something to quickly test it on an Opentitan branch [here](https://github.com/alexjones0/opentitan/tree/qemu_otp_testing), constructing an OTP image and removing some irrelevant keymgr checks from the DV test. This is sufficient to check that we can write a value to the SECRET2 partition (which is scrambled), and read it back and get the same value.

Edit: the third change to fix `DIRECT_ACCESS_REGWEN` is another small bug fix while I'm in the area which should be enough to get `otp_ctrl_mem_access_test` passing when QEMU support is added for this in OpenTitan.