### PR TITLE
`ot_spi_device`: discard all packets for a failed transaction

### DIFF
--- a/hw/opentitan/ot_spi_device.c
+++ b/hw/opentitan/ot_spi_device.c
@@ -2064,6 +2064,7 @@ static void ot_spi_device_chr_recv_discard(OtSPIDeviceState *s,
     (void)buf;
 
     ot_spi_device_chr_send_discard(s, size);
+    s->bus.byte_count -= size;
 }
 
 static void ot_spi_device_chr_recv_flash(OtSPIDeviceState *s,
@@ -2297,7 +2298,7 @@ static void ot_spi_device_chr_receive(void *opaque, const uint8_t *buf,
         break;
     }
 
-    if (!bus->byte_count) {
+    if (!bus->byte_count && bus->state != SPI_BUS_ERROR) {
         if (bus->release) {
             ot_spi_device_release(s);
         } else {

--- a/hw/opentitan/ot_spi_device.c
+++ b/hw/opentitan/ot_spi_device.c
@@ -458,6 +458,7 @@ typedef struct {
     Fifo8 chr_fifo; /* QEMU protocol input FIFO */
     uint8_t mode; /* Polarity/phase mismatch */
     bool release; /* Whether to release /CS on last byte */
+    bool failed_transaction; /* Whether to discard until /CS is deasserted */
     bool rev_rx; /* Reverse RX bits */
     bool rev_tx; /* Reverse TX bits */
 } SpiDeviceBus;
@@ -876,6 +877,7 @@ static void ot_spi_device_release(OtSPIDeviceState *s)
 
     BUS_CHANGE_STATE(s, IDLE);
     bus->byte_count = 0u;
+    bus->failed_transaction = false;
 
     bool update_irq = false;
     switch (ot_spi_device_get_mode(s)) {
@@ -2028,6 +2030,12 @@ static void ot_spi_device_chr_handle_header(OtSPIDeviceState *s)
         return;
     }
 
+    /* discard the packet if we're within a failed transaction */
+    if (bus->failed_transaction) {
+        BUS_CHANGE_STATE(s, DISCARD);
+        return;
+    }
+
     /* @todo: Check that the tpm chip-select was assigned.*/
     if (ot_spi_device_is_tpm_enabled(s)) {
         ot_spi_device_tpm_init_buffers(s);
@@ -2292,6 +2300,8 @@ static void ot_spi_device_chr_receive(void *opaque, const uint8_t *buf,
     case SPI_BUS_DISCARD:
     case SPI_BUS_ERROR:
         ot_spi_device_chr_recv_discard(s, buf, (unsigned)size);
+        /* we need to discard the other packets in this transaction */
+        bus->failed_transaction = true;
         break;
     default:
         g_assert_not_reached();


### PR DESCRIPTION
This changes the SPI device's discarding behaviour in two ways:

1. The byte count is correctly adjusted for discarded bytes so we can receive a new packet when it's finished.
2. We discard subsequent packets in a transaction if one of them fails. This ensures we treat the transaction as one and don't stop discarding at an arbitrary packet boundary.

This is motivated by seeing that QEMU never stops discarding after it receives an unrecognised flash command as part of a multi-packet transaction (e.g. a "read" transaction which sends a "write read command" packet with EOT=0 followed by a "read bytes" packet with EOT=1).