### PR TITLE
`ibex_csr`: Fix non-vectored mtvec write behaviour 

### DIFF
--- a/target/riscv/ibex_csr.c
+++ b/target/riscv/ibex_csr.c
@@ -113,8 +113,9 @@ static RISCVException write_mtvec(CPURISCVState *env, int csrno,
                       "CSR_MTVEC: reserved mode not supported 0x" TARGET_FMT_lx
                       "\n",
                       val);
-        /* WARL */
-        return RISCV_EXCP_NONE;
+        /* WARL, Ibex will tie any invalid mode writes to 0b01 (vectored) */
+        val &= ~3u;
+        val |= 1u;
     }
 
     /* bits [7:2] are always 0, address should be aligned in 256 bytes */

--- a/tests/opentitan/data/earlgrey-tests.txt
+++ b/tests/opentitan/data/earlgrey-tests.txt
@@ -640,6 +640,8 @@ pass: //third_party/riscv-compliance:I-CSRRWI-01_sim_qemu_rom_with_fake_keys
 pass: //third_party/riscv-compliance:I-CSRRWI-01_sim_qemu_sival_rom_ext
 pass: //third_party/riscv-compliance:I-DELAY_SLOTS-01_sim_qemu_rom_with_fake_keys
 pass: //third_party/riscv-compliance:I-DELAY_SLOTS-01_sim_qemu_sival_rom_ext
+pass: //third_party/riscv-compliance:I-ECALL-01_sim_qemu_rom_with_fake_keys
+pass: //third_party/riscv-compliance:I-ECALL-01_sim_qemu_sival_rom_ext
 pass: //third_party/riscv-compliance:I-ENDIANESS-01_sim_qemu_rom_with_fake_keys
 pass: //third_party/riscv-compliance:I-ENDIANESS-01_sim_qemu_sival_rom_ext
 pass: //third_party/riscv-compliance:I-IO-01_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
This is needed to allow the `I-ECALL-01` RISC-V compliance test to pass as it currently does on FPGA and silicon targets.
`mtvec` is WARL, and in reality will accept writes with invalid encode modes but will just tie them to vectored mode (1).