### PR TITLE
`ot_earlgrey`: Leave hart disabled on reset

### DIFF
--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -1720,7 +1720,7 @@ static void ot_eg_soc_reset_hold(Object *obj, ResetType type)
      * PowerManager takes care of managing Ibex reset when ready
      */
     CPUState *cs = CPU(s->devices[OT_EG_SOC_DEV_HART]);
-    cs->disabled = false;
+    cs->disabled = true;
 }
 
 static void ot_eg_soc_reset_exit(Object *obj, ResetType type)


### PR DESCRIPTION
I think this might have just been a small mistake missed in https://github.com/lowRISC/qemu/pull/186 (changes `cs->disabled = 1` to `cs->disabled = true` on Darjeeling, but `cs->disabled = 1` to `cs->disabled = false` on Earlgrey). 

The hart should be disabled on soc reset, and should instead be enabled by the PowerManager when the reset sequence has been properly handled, as the comment suggests.

This surprisingly wasn't causing many issues, but when using the debug module I was running into assertion failures surrounding reset sequences where QEMU tried to `reset_exit` Ibex despite having never `reset_enter`ed it.