### PR TITLE
`ot_earlgrey`: Stop disabling lc_ctrl state for Ibex

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -158,7 +158,8 @@ jobs:
       - name: Check EarlGrey VM execution
         run: |
           timeout -s KILL 4 ./qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -nographic \
-            -object ot-rom_img,id=rom,file=exit_eg.bin -d in_asm,int
+            -object ot-rom_img,id=rom,file=exit_eg.bin -global ot-ibex_wrapper.lc-ignore=on \
+            -d in_asm,int
       - name: Check Darjeeling VM execution
         run: |
           timeout -s KILL 4 ./qemu-system-riscv32 -M ot-darjeeling,no_epmp_cfg=true -nographic \

--- a/.gitlab-ci.d/opentitan/build.yml
+++ b/.gitlab-ci.d/opentitan/build.yml
@@ -28,6 +28,7 @@ build-clang:
         sed -E 's,'"$QEMU_DIR"',@QEMU_DIR@,g' > compile_commands.json.tpl
     - ../scripts/opentitan/swexit.py -t ibexdemo -b 0x0 -o exit_id.bin
     - ../scripts/opentitan/swexit.py -t earlgrey -b 0x80 -o exit_eg.bin
+    - ../scripts/opentitan/swexit.py -t darjeeling -b 0x80 -o exit_dj.bin
   artifacts:
     public: false
     expire_in: 1 hour

--- a/.gitlab-ci.d/opentitan/ot-smoke.yml
+++ b/.gitlab-ci.d/opentitan/ot-smoke.yml
@@ -10,6 +10,7 @@ smoke-tests-ot:
         -device loader,addr=0x100080,file=build/exit_id.bin -d in_asm,int
     - timeout -s KILL 4 build/qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -nographic
         -object ot-rom_img,id=rom,file=build/exit_eg.bin -d in_asm,int
+        -nographic -global ot-ibex_wrapper.lc-ignore=on
     - timeout -s KILL 4 build/qemu-system-riscv32 -M ot-darjeeling,no_epmp_cfg=true
         -object ot-rom_img,id=rom,file=build/exit_dj.bin -d in_asm,int
          -nographic -global ot-ibex_wrapper.lc-ignore=on

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -1347,9 +1347,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
         ),
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_UINT_PROP("edn-ep", 7u),
-            IBEX_DEV_UINT_PROP("num-regions", OT_EG_IBEX_WRAPPER_NUM_REGIONS),
-            /* remove the following line once LC state is implemented */
-            IBEX_DEV_BOOL_PROP("lc-ignore", true)
+            IBEX_DEV_UINT_PROP("num-regions", OT_EG_IBEX_WRAPPER_NUM_REGIONS)
         ),
     },
     [OT_EG_SOC_DEV_RV_DM] = {


### PR DESCRIPTION
See relevant comment here: https://github.com/lowRISC/qemu/pull/269#issuecomment-3469650725

I believe that this comment & property are now redundant because the LC state should be sufficiently emulated within the Earlgrey machine. As such, remove this default property and update the CI smoketest accordingly.