### PR TITLE
`opentitan`:  add missing `qemu/error-report.h` header files

### DIFF
--- a/hw/opentitan/ot_aes.c
+++ b/hw/opentitan/ot_aes.c
@@ -29,6 +29,7 @@
 
 #include "qemu/osdep.h"
 #include "qemu/bitmap.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qemu/main-loop.h"
 #include "qemu/timer.h"

--- a/hw/opentitan/ot_csrng.c
+++ b/hw/opentitan/ot_csrng.c
@@ -29,6 +29,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qemu/main-loop.h"
 #include "qemu/queue.h"

--- a/hw/opentitan/ot_dev_proxy.c
+++ b/hw/opentitan/ot_dev_proxy.c
@@ -26,7 +26,9 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/fifo8.h"
+#include "qemu/log-for-trace.h"
 #include "qemu/typedefs.h"
 #include "qapi/error.h"
 #include "qapi/qapi-commands-misc.h"

--- a/hw/opentitan/ot_dma.c
+++ b/hw/opentitan/ot_dma.c
@@ -30,6 +30,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qemu/timer.h"
 #include "qemu/typedefs.h"

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -46,6 +46,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qemu/memalign.h"
 #include "qemu/timer.h"

--- a/hw/opentitan/ot_gpio_dj.c
+++ b/hw/opentitan/ot_gpio_dj.c
@@ -27,6 +27,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qemu/typedefs.h"
 #include "chardev/char-fe.h"

--- a/hw/opentitan/ot_gpio_eg.c
+++ b/hw/opentitan/ot_gpio_eg.c
@@ -26,6 +26,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qemu/typedefs.h"
 #include "chardev/char-fe.h"

--- a/hw/opentitan/ot_otp_dj.c
+++ b/hw/opentitan/ot_otp_dj.c
@@ -33,6 +33,7 @@
 #define OT_OTP_COMPORTABLE_REGS
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qom/object.h"
 #include "hw/opentitan/ot_otp_dj.h"

--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -31,6 +31,7 @@
 #define OT_OTP_COMPORTABLE_REGS
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qom/object.h"
 #include "hw/opentitan/ot_otp_eg.h"

--- a/hw/opentitan/ot_otp_engine.c
+++ b/hw/opentitan/ot_otp_engine.c
@@ -32,6 +32,7 @@
 
 #include "qemu/osdep.h"
 #include "qemu/bswap.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qapi/error.h"
 #include "hw/opentitan/ot_alert.h"

--- a/hw/opentitan/ot_rstmgr.c
+++ b/hw/opentitan/ot_rstmgr.c
@@ -31,6 +31,7 @@
 
 #include "qemu/osdep.h"
 #include "qemu/bitops.h"
+#include "qemu/error-report.h"
 #include "qemu/log.h"
 #include "qemu/main-loop.h"
 #include "qemu/typedefs.h"

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -34,6 +34,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/error-report.h"
 #include "qemu/fifo8.h"
 #include "qemu/log.h"
 #include "chardev/char-fe.h"

--- a/hw/opentitan/ot_vmapper.c
+++ b/hw/opentitan/ot_vmapper.c
@@ -26,7 +26,7 @@
  */
 
 #include "qemu/osdep.h"
-#include "qemu/log.h"
+#include "qemu/error-report.h"
 #include "qemu/typedefs.h"
 #include "exec/exec-all.h"
 #include "exec/page-protection.h"


### PR DESCRIPTION
Depending on command line options, this file may not be automatically included and the build fails.