### PR TITLE
Add passing SPI Device TPM and Passthrough tests

### DIFF
--- a/tests/opentitan/data/earlgrey-tests.txt
+++ b/tests/opentitan/data/earlgrey-tests.txt
@@ -530,8 +530,12 @@ pass: //sw/device/tests:rv_timer_smoketest_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:rv_timer_smoketest_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:spi_device_flash_smoketest_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:spi_device_flash_smoketest_sim_qemu_sival_rom_ext
+pass: //sw/device/tests:spi_device_tpm_tx_rx_test_sim_qemu_rom_with_fake_keys
+pass: //sw/device/tests:spi_device_tpm_tx_rx_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:spi_host_irq_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:spi_host_irq_test_sim_qemu_sival_rom_ext
+pass: //sw/device/tests:spi_passthru_test_sim_qemu_rom_with_fake_keys
+pass: //sw/device/tests:spi_passthru_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:sram_ctrl_execution_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:sram_ctrl_execution_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:sram_ctrl_memset_test_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
Depends on [#28649](https://github.com/lowRISC/opentitan/pull/28649).