### PR TITLE
.github/workflows: eg_regression: fetch all OT commits

### DIFF
--- a/.github/workflows/eg_regression.yml
+++ b/.github/workflows/eg_regression.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           repository: ${{ inputs.opentitan_repo || 'lowRISC/opentitan' }}
           ref: ${{ inputs.opentitan_ref || 'earlgrey_1.0.0' }}
+          fetch-depth: 0 # fetch all commits to avoid bug with bitstream rule
 
       - name: Prepare OpenTitan environment
         uses: ./.github/actions/prepare-env


### PR DESCRIPTION
OpenTitan has a rule which searches an online cache for an FPGA bitstream close to the current commit. For this to work, we need all commits of the OpenTitan repository fetched. GitHub does a shallow fetch by default.

This commit fetches all commits until we can work out why sometimes the bitstream rule is being run for our QEMU regressions.