### PR TITLE
`ot_flash`: Allow reads of initialized PHY flash with an uninitialized flash_ctrl

### DIFF
--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -2198,7 +2198,6 @@ static void ot_flash_init_complete(void *opaque)
     trace_ot_flash_op_complete(s->ot_id, OP_NAME(s->op.kind), s->op.hw, true);
 
     s->op.kind = OP_NONE;
-    ot_flash_process_control_op(s);
 }
 
 static uint64_t ot_flash_regs_read(void *opaque, hwaddr addr, unsigned size)
@@ -2459,15 +2458,22 @@ static void ot_flash_regs_write(void *opaque, hwaddr addr, uint64_t val64,
         s->regs[reg] = val32;
 
         /*
-         * SW protocol ops are not processed until the phy controller is init;
-         * immediately after the flash arbiter permits hw ops to read keymgr
-         * secrets. So, we cannot perform a sw op until the flash_ctrl is
-         * initialized. However, if `start` is true, the arbiter processes the
-         * sw request immediately after init in `ot_flash_init_complete`.
+         * SW protocol operations are not processed until the PHY controller is
+         * initialized, but the protocol controller is not required to be
+         * initialized (i.e. before the scrambling keys are read). In such a
+         * case we *can* interact with the flash - we just do not buffer
+         * outgoing reads, but they are still permitted.
+         *
+         * We emulate the PHY as always being initialized, so there is no need
+         * to check for initialization here.
+         *
+         * Note for future implementation of scrambling: there is a special
+         * case for scrambled pages: when reading from a scrambled page with
+         * the flash_ctrl uninitialized, default scrambling keys hardcoded in
+         * the RTL are used instead of the (not yet) loaded flash addr/data
+         * keys.
          */
-        if (ot_flash_is_initialized(s)) {
-            ot_flash_process_control_op(s);
-        }
+        ot_flash_process_control_op(s);
         break;
     case R_ADDR:
         val32 &= R_ADDR_START_MASK;

--- a/tests/opentitan/data/earlgrey-tests.txt
+++ b/tests/opentitan/data/earlgrey-tests.txt
@@ -439,8 +439,8 @@ pass: //sw/device/tests:example_concurrency_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:example_concurrency_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:example_test_from_flash_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:example_test_from_flash_sim_qemu_sival_rom_ext
-pass: //sw/device/tests:flash_ctrl_clock_freqs_test_sim_qemu_rom_with_fake_keys
-pass: //sw/device/tests:flash_ctrl_clock_freqs_test_sim_qemu_sival_rom_ext
+flaky: //sw/device/tests:flash_ctrl_clock_freqs_test_sim_qemu_rom_with_fake_keys  # After processing commands for uninitialized flash, the timing gets tighter and this fails < 5% of the time.
+flaky: //sw/device/tests:flash_ctrl_clock_freqs_test_sim_qemu_sival_rom_ext  # After processing commands for uninitialized flash, the timing gets tighter and this fails < 5% of the time.
 pass: //sw/device/tests:flash_ctrl_info_access_lc_dev_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:flash_ctrl_info_access_lc_prod_end_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:flash_ctrl_info_access_lc_prod_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
See the comment in the commit. It turns out that initialization is even more of a special-case than previously realized in the flash controller.

This is needed to get some SRAM execution flows working (which read from flash with the flash_ctrl uninitialized, see `sram_start.S` and `ast_program.c` in OpenTitan). Examples are e.g. the `//sw/device/tests:rv_core_ibex_isa_test_{}` or `//sw/device/tests:rv_core_ibex_epmp_test_{}` in upstream OpenTitan.