### PR TITLE
Upgrade to LLVM 21

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -18,9 +18,9 @@ jobs:
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key |
             sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" &&
+          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" &&
           sudo apt-get update &&
-          sudo apt-get install -y git make pkg-config clang-20 cmake ninja-build python3 rust-all \
+          sudo apt-get install -y git make pkg-config clang-21 cmake ninja-build python3 rust-all \
             libpixman-1-dev libglib2.0-dev
       - name: Check out QEMU
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
           git clean -dffx subprojects
           mkdir build-clang
           (cd build-clang &&
-           ../configure --cc=clang-20 --disable-werror --disable-install-blobs \
+           ../configure --cc=clang-21 --disable-werror --disable-install-blobs \
              --target-list=riscv32-softmmu,riscv64-softmmu)
       - name: Build
         run: |
@@ -74,9 +74,9 @@ jobs:
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key |
             sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" &&
+          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" &&
           sudo apt-get update &&
-          sudo apt-get install -y clang-format-20
+          sudo apt-get install -y clang-format-21
       - name: Check out QEMU
         uses: actions/checkout@v4
       - name: Check C code format
@@ -107,9 +107,9 @@ jobs:
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key |
             sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" &&
+          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" &&
           sudo apt-get update &&
-          sudo apt-get install -y clang-tidy-20 libglib2.0-dev
+          sudo apt-get install -y clang-tidy-21 libglib2.0-dev
       - name: Check out QEMU
         uses: actions/checkout@v4
       - name: Download QEMU source artifacts
@@ -173,7 +173,7 @@ jobs:
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key |
           sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" &&
+          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" &&
           sudo apt-get update &&
           sudo apt-get install -y git make pkg-config gcc cmake ninja-build python3 rust-all \
             libpixman-1-dev libglib2.0-dev

--- a/.gitlab-ci.d/opentitan/build.yml
+++ b/.gitlab-ci.d/opentitan/build.yml
@@ -19,7 +19,7 @@ build-clang:
     - git clean -dffx subprojects
     - mkdir build
     - cd build
-    - ../configure --cc=clang-19 --disable-werror $QEMU_BUILD_OPTS
+    - ../configure --cc=clang-21 --disable-werror $QEMU_BUILD_OPTS
         --target-list=riscv32-softmmu,riscv64-softmmu,x86_64-linux-user
     - ninja
     - ninja qemu-img

--- a/hw/opentitan/ot_aes.c
+++ b/hw/opentitan/ot_aes.c
@@ -147,7 +147,7 @@ static_assert(OT_AES_KEY_SIZE == (PARAM_NUM_REGS_KEY * sizeof(uint32_t)),
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_aon_timer.c
+++ b/hw/opentitan/ot_aon_timer.c
@@ -78,7 +78,7 @@ REG32(WKUP_CAUSE, 0x34u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char REG_NAMES[REGS_COUNT][20u] = {

--- a/hw/opentitan/ot_ast_dj.c
+++ b/hw/opentitan/ot_ast_dj.c
@@ -99,13 +99,13 @@ REG32(REGB4, 0x210u)
 #define REGSA_COUNT (RA_LAST_REG + 1u)
 #define REGSA_SIZE  (REGSA_COUNT * sizeof(uint32_t))
 #define REGA_NAME(_reg_) \
-    ((((_reg_) <= REGSA_COUNT) && REGA_NAMES[_reg_]) ? REGA_NAMES[_reg_] : "?")
+    ((((_reg_) < REGSA_COUNT) && REGA_NAMES[_reg_]) ? REGA_NAMES[_reg_] : "?")
 
 #define RB_LAST_REG (R_REGB4)
 #define REGSB_COUNT (RB_LAST_REG + 1u)
 #define REGSB_SIZE  (REGSB_COUNT * sizeof(uint32_t))
 #define REGB_NAME(_reg_) \
-    ((((_reg_) <= REGSB_COUNT) && REGB_NAMES[_reg_]) ? REGB_NAMES[_reg_] : "?")
+    ((((_reg_) < REGSB_COUNT) && REGB_NAMES[_reg_]) ? REGB_NAMES[_reg_] : "?")
 
 #define REGS_SIZE (A_REGB4 + sizeof(uint32_t))
 #define REG_NAME(_reg_) \

--- a/hw/opentitan/ot_ast_eg.c
+++ b/hw/opentitan/ot_ast_eg.c
@@ -98,13 +98,13 @@ REG32(REGB4, 0x210u)
 #define REGSA_COUNT (RA_LAST_REG + 1u)
 #define REGSA_SIZE  (REGSA_COUNT * sizeof(uint32_t))
 #define REGA_NAME(_reg_) \
-    ((((_reg_) <= REGSA_COUNT) && REGA_NAMES[_reg_]) ? REGA_NAMES[_reg_] : "?")
+    ((((_reg_) < REGSA_COUNT) && REGA_NAMES[_reg_]) ? REGA_NAMES[_reg_] : "?")
 
 #define RB_LAST_REG (R_REGB4)
 #define REGSB_COUNT (RB_LAST_REG + 1u)
 #define REGSB_SIZE  (REGSB_COUNT * sizeof(uint32_t))
 #define REGB_NAME(_reg_) \
-    ((((_reg_) <= REGSB_COUNT) && REGB_NAMES[_reg_]) ? REGB_NAMES[_reg_] : "?")
+    ((((_reg_) < REGSB_COUNT) && REGB_NAMES[_reg_]) ? REGB_NAMES[_reg_] : "?")
 
 #define REGS_SIZE (A_REGB4 + sizeof(uint32_t))
 #define REG_NAME(_reg_) \

--- a/hw/opentitan/ot_clkmgr.c
+++ b/hw/opentitan/ot_clkmgr.c
@@ -89,7 +89,7 @@ REG32(MEASURE_REG_BASE, A_RECOV_ERR_CODE)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define ALERT_TEST_MASK \
     (R_ALERT_TEST_RECOV_FAULT_MASK | R_ALERT_TEST_FATAL_FAULT_MASK)

--- a/hw/opentitan/ot_csrng.c
+++ b/hw/opentitan/ot_csrng.c
@@ -145,7 +145,7 @@ REG32(MAIN_SM_STATE, 0x5cu)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define INTR_MASK \
     (INTR_CS_CMD_REQ_DONE_MASK | INTR_CS_ENTROPY_REQ_MASK | \

--- a/hw/opentitan/ot_dma.c
+++ b/hw/opentitan/ot_dma.c
@@ -289,7 +289,7 @@ struct OtDMAClass {
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define INTR_MASK \
     (INTR_DMA_DONE_MASK | INTR_DMA_ERROR_MASK | INTR_DMA_MEM_BUF_LIMIT_MASK)

--- a/hw/opentitan/ot_edn.c
+++ b/hw/opentitan/ot_edn.c
@@ -110,7 +110,7 @@ REG32(MAIN_SM_STATE, 0x44u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define INTR_MASK (INTR_EDN_CMD_REQ_DONE_MASK | INTR_EDN_FATAL_ERR_MASK)
 #define ALERT_TEST_MASK \

--- a/hw/opentitan/ot_entropy_src.c
+++ b/hw/opentitan/ot_entropy_src.c
@@ -302,7 +302,7 @@ REG32(MAIN_SM_STATE, 0xc0u)
 #define REGS_LO_SIZE  (REGS_LO_COUNT * sizeof(uint32_t))
 #define REGS_LO_BASE  0x00u
 #define REG_LO_NAME(_reg_) \
-    ((((_reg_) <= REGS_LO_COUNT) && REG_LO_NAMES[_reg_]) ? \
+    ((((_reg_) < REGS_LO_COUNT) && REG_LO_NAMES[_reg_]) ? \
          REG_LO_NAMES[_reg_] : \
          "?")
 
@@ -312,7 +312,7 @@ REG32(MAIN_SM_STATE, 0xc0u)
 #define REGS_REV_SIZE  (REGS_REV_COUNT * sizeof(uint32_t))
 #define REGS_REV_BASE  0x1cu
 #define REG_REV_NAME(_reg_) \
-    ((((_reg_) <= REGS_REV_COUNT) && REG_REV_NAMES[_reg_]) ? \
+    ((((_reg_) < REGS_REV_COUNT) && REG_REV_NAMES[_reg_]) ? \
          REG_REV_NAMES[_reg_] : \
          "?")
 
@@ -322,7 +322,7 @@ REG32(MAIN_SM_STATE, 0xc0u)
 #define REGS_HI_V2_BASE 0x20u
 #define REGS_HI_V3_BASE 0x1cu
 #define REG_HI_NAME(_reg_) \
-    ((((_reg_) <= REGS_HI_COUNT) && REG_HI_NAMES[_reg_]) ? \
+    ((((_reg_) < REGS_HI_COUNT) && REG_HI_NAMES[_reg_]) ? \
          REG_HI_NAMES[_reg_] : \
          "?")
 

--- a/hw/opentitan/ot_flash.c
+++ b/hw/opentitan/ot_flash.c
@@ -508,7 +508,7 @@ typedef enum {
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {
@@ -629,7 +629,7 @@ static const char *REG_NAMES[REGS_COUNT] = {
 #define CSRS_COUNT (R_LAST_CSR + 1u)
 #define CSRS_SIZE  (CSRS_COUNT * sizeof(uint32_t))
 #define CSR_NAME(_reg_) \
-    ((((_reg_) <= CSRS_COUNT) && CSR_NAMES[_reg_]) ? CSR_NAMES[_reg_] : "?")
+    ((((_reg_) < CSRS_COUNT) && CSR_NAMES[_reg_]) ? CSR_NAMES[_reg_] : "?")
 
 #define CSR_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *CSR_NAMES[CSRS_COUNT] = {

--- a/hw/opentitan/ot_gpio_dj.c
+++ b/hw/opentitan/ot_gpio_dj.c
@@ -79,7 +79,7 @@ REG32(CTRL_EN_INPUT_FILTER, 0x44u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define ALERT_TEST_MASK (R_ALERT_TEST_FATAL_FAULT_ERR_MASK)
 

--- a/hw/opentitan/ot_gpio_eg.c
+++ b/hw/opentitan/ot_gpio_eg.c
@@ -74,7 +74,7 @@ REG32(CTRL_EN_INPUT_FILTER, 0x3cu)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define ALERT_TEST_MASK (R_ALERT_TEST_FATAL_FAULT_ERR_MASK)
 

--- a/hw/opentitan/ot_hmac.c
+++ b/hw/opentitan/ot_hmac.c
@@ -169,7 +169,7 @@ REG32(MSG_LENGTH_UPPER, 0xe8u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_i2c.c
+++ b/hw/opentitan/ot_i2c.c
@@ -240,7 +240,7 @@ REG32(TARGET_EVENTS, 0x7cu)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_ibex_wrapper.c
+++ b/hw/opentitan/ot_ibex_wrapper.c
@@ -1252,6 +1252,7 @@ static void ot_ibex_wrapper_fill_tables(OtIbexWrapperState *s)
     regs = &s->regs.alert_test;
     unsigned rix;
     for (rix = 0; rix <= LAST_STATIC_REG_POS; rix++) {
+        /* NOLINTNEXTLINE */
         s->access_regs[rix] = &regs[rix];
     }
 

--- a/hw/opentitan/ot_keymgr.c
+++ b/hw/opentitan/ot_keymgr.c
@@ -542,7 +542,7 @@ static const char *REG_NAMES[REGS_COUNT] = {
 };
 #undef REG_NAME_ENTRY
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define STAGE_ENTRY(_st_) [KEYMGR_STAGE_##_st_] = stringify(_st_)
 static const char *STAGE_NAMES[] = {

--- a/hw/opentitan/ot_keymgr_dpe.c
+++ b/hw/opentitan/ot_keymgr_dpe.c
@@ -493,7 +493,7 @@ static const char *REG_NAMES[REGS_COUNT] = {
 };
 #undef REG_ENTRY
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define OP_ENTRY(_op_) [KEYMGR_DPE_OP_##_op_] = stringify(_op_)
 static const char *OP_NAMES[] = {

--- a/hw/opentitan/ot_kmac.c
+++ b/hw/opentitan/ot_kmac.c
@@ -241,7 +241,7 @@ static const char *ERR_NAMES[] = {
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_lc_ctrl.c
+++ b/hw/opentitan/ot_lc_ctrl.c
@@ -136,7 +136,7 @@ REG32(MANUF_STATE_7, 0x88u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define R_FIRST_EXCLUSIVE_REG (R_TRANSITION_TOKEN_0)
 #define R_LAST_EXCLUSIVE_REG  (R_TRANSITION_TARGET)

--- a/hw/opentitan/ot_mbx.c
+++ b/hw/opentitan/ot_mbx.c
@@ -137,7 +137,7 @@ static_assert(OT_MBX_HOST_REGS_COUNT == REGS_HOST_COUNT, "Invalid HOST regs");
 static_assert(OT_MBX_SYS_REGS_COUNT == REGS_SYS_COUNT, "Invalid SYS regs");
 
 #define REG_NAME(_kind_, _reg_) \
-    ((((_reg_) <= REGS_##_kind_##_COUNT) && REG_##_kind_##_NAMES[_reg_]) ? \
+    ((((_reg_) < REGS_##_kind_##_COUNT) && REG_##_kind_##_NAMES[_reg_]) ? \
          REG_##_kind_##_NAMES[_reg_] : \
          "?")
 

--- a/hw/opentitan/ot_otbn.c
+++ b/hw/opentitan/ot_otbn.c
@@ -111,7 +111,7 @@ REG32(LOAD_CHECKSUM, 0x28u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_otp_dj.c
+++ b/hw/opentitan/ot_otp_dj.c
@@ -410,7 +410,7 @@ REG32(LC_STATE, 16344u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 /* note: useless casts are required for GCC linter */
 static_assert((unsigned)R_STATUS == (unsigned)R_OTP_FIRST_IMPL_REG,

--- a/hw/opentitan/ot_otp_eg.c
+++ b/hw/opentitan/ot_otp_eg.c
@@ -359,7 +359,7 @@ REG32(LC_STATE, 2008u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 /* note: useless casts are required for GCC linter */
 static_assert((unsigned)R_STATUS == (unsigned)R_OTP_FIRST_IMPL_REG,

--- a/hw/opentitan/ot_otp_ot_be.c
+++ b/hw/opentitan/ot_otp_ot_be.c
@@ -96,7 +96,7 @@ REG32(CSR7, 0x1cu)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 
 /* clang-format off */

--- a/hw/opentitan/ot_plic_ext.c
+++ b/hw/opentitan/ot_plic_ext.c
@@ -57,7 +57,7 @@ REG32(ALERT_TEST, 0x0u)
 #define MSIP_REGS_COUNT (R_LAST_MSIP_REG + 1u)
 #define MSIP_REGS_SIZE  (MSIP_REGS_COUNT * sizeof(uint32_t))
 #define MSIP_REG_NAME(_reg_) \
-    ((((_reg_) <= MSIP_REGS_COUNT) && MSIP_REG_NAMES[_reg_]) ? \
+    ((((_reg_) < MSIP_REGS_COUNT) && MSIP_REG_NAMES[_reg_]) ? \
          MSIP_REG_NAMES[_reg_] : \
          "?")
 
@@ -65,7 +65,7 @@ REG32(ALERT_TEST, 0x0u)
 #define ALERT_REGS_COUNT (R_LAST_ALERT_REG + 1u)
 #define ALERT_REGS_SIZE  (ALERT_REGS_COUNT * sizeof(uint32_t))
 #define ALERT_REG_NAME(_reg_) \
-    ((((_reg_) <= ALERT_REGS_COUNT) && ALERT_REG_NAMES[_reg_]) ? \
+    ((((_reg_) < ALERT_REGS_COUNT) && ALERT_REG_NAMES[_reg_]) ? \
          ALERT_REG_NAMES[_reg_] : \
          "?")
 

--- a/hw/opentitan/ot_pwrmgr.c
+++ b/hw/opentitan/ot_pwrmgr.c
@@ -106,7 +106,7 @@ REG32(FAULT_STATUS, 0x40u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_rom_ctrl.c
+++ b/hw/opentitan/ot_rom_ctrl.c
@@ -88,7 +88,7 @@ REG32(EXP_DIGEST_7, 0x44u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_rstmgr.c
+++ b/hw/opentitan/ot_rstmgr.c
@@ -120,7 +120,7 @@ REG32(ERR_CODE, 0x6cu)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 /* clang-format off */
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)

--- a/hw/opentitan/ot_sensor_eg.c
+++ b/hw/opentitan/ot_sensor_eg.c
@@ -148,7 +148,7 @@ REG32(MANUAL_PAD_ATTR_3, 0x70u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 /* clang-format off */

--- a/hw/opentitan/ot_soc_dbg_ctrl.c
+++ b/hw/opentitan/ot_soc_dbg_ctrl.c
@@ -218,7 +218,7 @@ static_assert(OT_SOC_DBG_ST_COUNT == OT_LC_SOC_DBG_STATE_COUNT,
 #define ROM_MASK ((1u << (R_BOOT_STATUS_ROM_CTRL_DONE_LENGTH - 1u)) - 1u)
 
 #define REG_NAME(_kind_, _reg_) \
-    ((((_reg_) <= REGS_##_kind_##_COUNT) && REG_##_kind_##_NAMES[_reg_]) ? \
+    ((((_reg_) < REGS_##_kind_##_COUNT) && REG_##_kind_##_NAMES[_reg_]) ? \
          REG_##_kind_##_NAMES[_reg_] : \
          "?")
 

--- a/hw/opentitan/ot_soc_dbg_ctrl.c
+++ b/hw/opentitan/ot_soc_dbg_ctrl.c
@@ -405,7 +405,7 @@ static void ot_soc_dbg_ctrl_tick_fsm(OtSoCDbgCtrlState *s)
 
     /* as with PwrMgr, use simple boolean value, not MuBi4 */
     int cpu_boot_done_i = (int)cpu_boot_done;
-    if (ibex_irq_get_level(&s->continue_cpu_boot[CONTINUE_CPU_BOOT_COUNT]) !=
+    if (ibex_irq_get_level(&s->continue_cpu_boot[CONTINUE_CPU_BOOT_DONE]) !=
         cpu_boot_done_i) {
         trace_ot_soc_dbg_ctrl_cpu_boot_done(s->ot_id, cpu_boot_done_i);
     }

--- a/hw/opentitan/ot_soc_proxy.c
+++ b/hw/opentitan/ot_soc_proxy.c
@@ -77,7 +77,7 @@ static_assert(1u + ALERT_TEST_FATAL_ALERT_EXTERNAL_COUNT +
 static_assert(OT_SOC_PROXY_REGS_COUNT == REGS_COUNT, "Invalid regs");
 
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 

--- a/hw/opentitan/ot_spi_device.c
+++ b/hw/opentitan/ot_spi_device.c
@@ -506,7 +506,7 @@ struct OtSPIDeviceClass {
 #define SPI_REGS_COUNT (R_SPI_LAST_REG + 1u)
 #define SPI_REGS_SIZE  (SPI_REGS_COUNT * sizeof(uint32_t))
 #define SPI_REG_NAME(_reg_) \
-    ((((_reg_) <= SPI_REGS_COUNT) && SPI_REG_NAMES[_reg_]) ? \
+    ((((_reg_) < SPI_REGS_COUNT) && SPI_REG_NAMES[_reg_]) ? \
          SPI_REG_NAMES[_reg_] : \
          "?")
 
@@ -514,7 +514,7 @@ struct OtSPIDeviceClass {
 #define TPM_REGS_COUNT (R_TPM_LAST_REG + 1u)
 #define TPM_REGS_SIZE  (TPM_REGS_COUNT * sizeof(uint32_t))
 #define TPM_REG_NAME(_reg_) \
-    ((((_reg_) <= TPM_REGS_COUNT) && TPM_REG_NAMES[_reg_]) ? \
+    ((((_reg_) < TPM_REGS_COUNT) && TPM_REG_NAMES[_reg_]) ? \
          TPM_REG_NAMES[_reg_] : \
          "?")
 

--- a/hw/opentitan/ot_spi_host.c
+++ b/hw/opentitan/ot_spi_host.c
@@ -209,7 +209,7 @@ REG32(EVENT_ENABLE, 0x34u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_sram_ctrl.c
+++ b/hw/opentitan/ot_sram_ctrl.c
@@ -86,7 +86,7 @@ REG32(READBACK, 0x20u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define INIT_TIMER_CHUNK_NS    100000 /* 100 us */
 #define INIT_TIMER_CHUNK_WORDS (4096u / sizeof(uint32_t)) /* 4 KB */

--- a/hw/opentitan/ot_timer.c
+++ b/hw/opentitan/ot_timer.c
@@ -63,7 +63,7 @@ REG32(COMPARE_UPPER0_0, 0x11cu)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_uart.c
+++ b/hw/opentitan/ot_uart.c
@@ -125,7 +125,7 @@ REG32(TIMEOUT_CTRL, 0x30u)
 #define REGS_COUNT (R_LAST_REG + 1u)
 #define REGS_SIZE  (REGS_COUNT * sizeof(uint32_t))
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -539,7 +539,7 @@ struct OtUsbdevState {
 };
 
 #define REG_NAME(_reg_) \
-    ((((_reg_) <= REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
+    ((((_reg_) < REGS_COUNT) && REG_NAMES[_reg_]) ? REG_NAMES[_reg_] : "?")
 
 #define REG_NAME_ENTRY(_reg_) [R_##_reg_] = stringify(_reg_)
 static const char *REG_NAMES[REGS_COUNT] = {

--- a/hw/riscv/ibexdemo.c
+++ b/hw/riscv/ibexdemo.c
@@ -1,7 +1,7 @@
 /*
  * QEMU RISC-V Board Compatible with Ibex Demo System FPGA platform
  *
- * Copyright (c) 2022-2024 Rivos, Inc.
+ * Copyright (c) 2022-2025 Rivos, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -63,6 +63,7 @@ static void ibexdemo_soc_uart_configure(
 /* Constants */
 /* ------------------------------------------------------------------------ */
 
+/* clang-format off */
 static const uint32_t IBEXDEMO_BOOT[] = {
     /* Exception vectors */
     0x0840006fu, 0x0800006fu, 0x07c0006fu, 0x0780006fu, 0x0740006fu,
@@ -78,6 +79,7 @@ static const uint32_t IBEXDEMO_BOOT[] = {
     0x10500073u, /* wfi */
     0x0000bff5u, /* j blank_loop */
 };
+/* clang-format on */
 
 enum IbexDemoSocDevice {
     IBEXDEMO_SOC_DEV_DM,

--- a/scripts/opentitan/autoreg.py
+++ b/scripts/opentitan/autoreg.py
@@ -998,7 +998,7 @@ class QEMUAutoReg(AutoReg):
             base = self._group_offsets[group]
             lines.append(f'#define REGS{sep}BASE 0x{base:0{self._nibcount}x}u')
         lines.append(f'#define REG{sep}NAME(_reg_) \\')
-        lines.append(f'    ((((_reg_) <= REGS{sep}COUNT) && '
+        lines.append(f'    ((((_reg_) < REGS{sep}COUNT) && '
                      f'REG{sep}NAMES[_reg_]) ? REG{sep}NAMES[_reg_] : "?")')
         lines.append('')
         print('\n'.join(lines), file=tfp)

--- a/scripts/opentitan/clang-format.yml
+++ b/scripts/opentitan/clang-format.yml
@@ -118,6 +118,7 @@ BreakBeforeBraces: Custom
 BreakBeforeConceptDeclarations: Always
 BreakBeforeInheritanceComma: false
 BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTemplateCloser: false
 BreakBeforeTernaryOperators: false
 BreakBinaryOperations: Never
 BreakConstructorInitializers: BeforeColon
@@ -137,6 +138,7 @@ DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
+EnumTrailingComma: Leave
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
@@ -229,6 +231,7 @@ ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+OneLineFormatOffRegex: ''
 PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 0
 PenaltyBreakBeforeFirstCallParameter: 500
@@ -256,11 +259,14 @@ RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SkipMacroDefinitionBody: false
-SortIncludes:    CaseInsensitive
+SortIncludes:
+  Enabled: true
+  IgnoreCase: true
 SortJavaStaticImport: Before
 SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
+SpaceAfterOperatorKeyword: false
 SpaceAfterTemplateKeyword: true
 SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
@@ -275,7 +281,7 @@ SpaceBeforeParensOptions:
   AfterForeachMacros: true
   AfterFunctionDeclarationName: false
   AfterFunctionDefinitionName: false
-  AfterIfMacros:   true
+  AfterIfMacros: true
   AfterOverloadedOperator: false
   AfterPlacementOperator: true
   AfterRequiresInClause: false

--- a/scripts/opentitan/clang-tidy.yml
+++ b/scripts/opentitan/clang-tidy.yml
@@ -37,7 +37,8 @@ Checks:          '*,
                   -readability-isolate-declaration,
                   -readability-math-missing-parentheses,
                   -readability-redundant-casting,
-                  -readability-redundant-declaration'
+                  -readability-redundant-declaration,
+                  -readability-use-concise-preprocessor-directives'
 
 UseColor: true
 SystemHeaders: false

--- a/scripts/opentitan/ot-format.sh
+++ b/scripts/opentitan/ot-format.sh
@@ -3,9 +3,9 @@
 # Copyright (c) 2024-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-EXPECTED_VERSION="20"
+EXPECTED_VERSION="21"
 
-# find clang-format executable: either 'clang-format-19' or 'clang-format'
+# find clang-format executable: either 'clang-format-XX,' or 'clang-format'
 for ver_suffix in "-${EXPECTED_VERSION}" ""; do
     clangformat="$(which clang-format${ver_suffix} 2>/dev/null)"
     if [ -n "${clangformat}" ]; then

--- a/scripts/opentitan/ot-tidy.py
+++ b/scripts/opentitan/ot-tidy.py
@@ -21,7 +21,7 @@ from os import execvp, scandir
 from os.path import abspath, dirname, isfile, join, normpath, relpath, splitext
 from traceback import format_exc
 
-LLVM_MAJOR = 20
+LLVM_MAJOR = 21
 """LLVM major version to check for"""
 
 OT_SCRIPTS = dirname(abspath(__file__))

--- a/scripts/opentitan/ot-tidy.sh
+++ b/scripts/opentitan/ot-tidy.sh
@@ -3,9 +3,9 @@
 # Copyright (c) 2024-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
-EXPECTED_VERSION="20"
+EXPECTED_VERSION="21"
 
-# find clang-tidy executable: either 'clang-tidy-19' or 'clang-tidy'
+# find clang-tidy executable: either 'clang-tidy-XX' or 'clang-tidy'
 for ver_suffix in "-${EXPECTED_VERSION}" ""; do
     clangtidy="$(which clang-tidy${ver_suffix} 2>/dev/null)"
     if [ -n "${clangtidy}" ]; then


### PR DESCRIPTION
Upgrade clang-cc, clang-format and clang-tidy to LLVM 21.

Address potential out-of-bound access when decoding invalid register addresses into register names. 