### PR TITLE
`dm`: Fix / workaround issues with halts during & before resets

### DIFF
--- a/hw/misc/pulp_rv_dm.c
+++ b/hw/misc/pulp_rv_dm.c
@@ -482,6 +482,8 @@ static void pulp_rv_dm_reset(DeviceState *dev)
 
     memset(memory_region_get_ram_ptr(&s->prog), 0, PULP_RV_DM_PROG_SIZE);
     memset(s->dmflag_regs, 0, sizeof(s->dmflag_regs));
+
+    s->idle_bm = 0;
 }
 
 static void pulp_rv_dm_init(Object *obj)

--- a/hw/riscv/dm.c
+++ b/hw/riscv/dm.c
@@ -334,6 +334,7 @@ struct RISCVDMState {
     const char *soc; /* Subsystem name, for debug */
     uint64_t nonexistent_bm; /* Selected harts that are not existent */
     uint64_t unavailable_bm; /* Selected harts that are not available */
+    uint64_t haltreq_bm; /* Selected harts that have a pending halt request */
     uint64_t to_go_bm; /* Harts that have been flagged for debug exec */
     uint32_t address; /* DM register addr: only bADDRESS_BITS..b0 are used */
     uint32_t *regs; /* Debug module register values */
@@ -1335,6 +1336,8 @@ static CmdErr riscv_dm_dmcontrol_write(RISCVDMState *dm, uint32_t value)
                     trace_riscv_dm_unavailable_hart_control(dm->soc, hartsel,
                                                             "halt");
                     ret = CMD_ERR_HALT_RESUME;
+                    /* flag the haltreq as pending while unavailable */
+                    dm->haltreq_bm |= hartbit;
                 } else {
                     riscv_dm_halt_hart(dm, hartsel);
                 }
@@ -1538,6 +1541,27 @@ static CmdErr riscv_dm_dmstatus_read(RISCVDMState *dm, uint32_t *value)
             trace_riscv_dm_status(dm->soc, cs->cpu_index, "became available");
             /* clear the unavailability flag and resume w/ "regular" states */
             dm->unavailable_bm &= ~mask;
+
+            /*
+             * If a pending haltreq exists for this hart, enter debug mode.
+             *
+             * @todo: This is a workaround for the fact that the current
+             * implementation does not conform to the debug specification. See
+             * e.g. section C.1.4: "When a hart comes out of reset and haltreq
+             * is set, the hart will immediately enter Debug Mode". To support
+             * this the CPU would need to query the DM when it begins executing
+             * instructions, and hence would need a reference to the DM, which
+             * is not ideal.
+             *
+             * For now, we can support most real use cases by exploiting the
+             * fact that reasonable SW will usually send a haltreq and then
+             * repeatedly poll `dmstatus` to see the hart(s) halt. Hence, we
+             * latch haltreqs for unresponsive cores and halt any hart that is
+             * polled as newly available/responsive on a `dmstatus` read.
+             */
+            if (dm->haltreq_bm & mask) {
+                riscv_dm_halt_hart(dm, hix);
+            }
         }
         if (hart->resumed) {
             resumeack += 1;
@@ -2412,6 +2436,7 @@ static void riscv_dm_halt_hart(RISCVDMState *dm, unsigned hartsel)
 
     /* Note: NMI are not yet supported */
     cpu_exit(cs);
+    dm->haltreq_bm &= ~(1u << hartsel);
     /* not sure if the real HW clear this flag on halt */
     dm->hart->resumed = false;
     riscv_dm_set_cs(dm, true);
@@ -2573,6 +2598,7 @@ static void riscv_dm_reset_enter(Object *obj, ResetType type)
     /* Hart statuses are updated on reset_exit */
     dm->nonexistent_bm = 0;
     dm->unavailable_bm = 0;
+    dm->haltreq_bm = 0;
     dm->address = 0;
     dm->to_go_bm = 0;
     for (unsigned ix = 0; ix < dm->hart_count; ix++) {


### PR DESCRIPTION
This PR contains two commits aimed at addressing flaky/inconsistent JTAG behaviour seen in various OpenTitan tests which appeared to originate from resetting and then halting the hart using the RV_DM over JTAG.

The first commit contains a bug fix to the `pulp_rv_dm` where harts could be seen as idle/halted across being reset (and no longer being halted), causing halt acknowledgements to not be transmitted due to caching. The second commit contains a  work-around (self-contained within `dm.c` without changes to the RISC-V CPU) to address the fact that halt requests sent to unresponsive harts are currently dropped whereas the RISC-V Debug specification states that they should instead be applied immediately when the hart becomes responsive. See the commit messages for more detailed explanations.

Also, as a related question (not planning to address in this PR): I have noticed in `dm.c` that upon an NDM reset the entire system is reset (which appears to include the debug module itself, from tracing) despite the fact that the DM itself is not supposed to be reset. I wonder if there's some logic I'm missing that means this reset is not a problem or if this could cause other issues down the line?