### PR TITLE
`ot_usbdev`: improve OUT transfers and introduce a weak form of scheduling

### DIFF
--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -54,6 +54,8 @@
 #define USBDEV_PARAM_NUM_ALERTS  1u
 #define USBDEV_PARAM_REG_WIDTH   32u
 
+#define USBDEV_ALL_EP_MASK ((1u << USBDEV_PARAM_N_ENDPOINTS) - 1u)
+
 /*
  * The following are not parameters of the IP but hardcoded
  * constants in the RTL.
@@ -1621,7 +1623,7 @@ ot_usbdev_update_ep_enabled(OtUsbdevState *s, hwaddr reg, uint32_t val32)
 {
     /* Find which endpoints have been disabled */
     uint32_t disabled_ep = s->regs[reg] & ~val32;
-    s->regs[reg] = val32 & ((1u << USBDEV_PARAM_N_ENDPOINTS) - 1u);
+    s->regs[reg] = val32 & USBDEV_ALL_EP_MASK;
 
     bool dir_in = reg == R_EP_IN_ENABLE;
     ot_usbdev_update_ep_xfers(s, dir_in, disabled_ep);
@@ -1640,9 +1642,8 @@ static void
 ot_usbdev_update_ep_stalled(OtUsbdevState *s, hwaddr reg, uint32_t val32)
 {
     /* Find which endpoints have been stalled */
-    uint32_t stalled_ep =
-        (~s->regs[reg] & val32) & ((1u << USBDEV_PARAM_N_ENDPOINTS) - 1u);
-    s->regs[reg] = val32 & ((1u << USBDEV_PARAM_N_ENDPOINTS) - 1u);
+    uint32_t stalled_ep = (~s->regs[reg] & val32) & USBDEV_ALL_EP_MASK;
+    s->regs[reg] = val32 & USBDEV_ALL_EP_MASK;
 
     bool dir_in = reg == R_IN_STALL;
     ot_usbdev_update_ep_xfers(s, dir_in, stalled_ep);

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -1626,6 +1626,11 @@ ot_usbdev_update_ep_enabled(OtUsbdevState *s, hwaddr reg, uint32_t val32)
     s->regs[reg] = val32 & USBDEV_ALL_EP_MASK;
 
     bool dir_in = reg == R_EP_IN_ENABLE;
+    /*
+     * Only update disabled endpoints: the endpoints which became enabled
+     * cannot have any pending transfers since ot_usbdev_advance_transfer_out
+     * automatically completes transfers on disabled endpoints.
+     */
     ot_usbdev_update_ep_xfers(s, dir_in, disabled_ep);
 }
 
@@ -1646,6 +1651,11 @@ ot_usbdev_update_ep_stalled(OtUsbdevState *s, hwaddr reg, uint32_t val32)
     s->regs[reg] = val32 & USBDEV_ALL_EP_MASK;
 
     bool dir_in = reg == R_IN_STALL;
+    /*
+     * Only update stalled endpoints: the endpoints which became unstalled
+     * cannot have any pending transfers since ot_usbdev_advance_transfer_out
+     * automatically completes transfers on stalled endpoints.
+     */
     ot_usbdev_update_ep_xfers(s, dir_in, stalled_ep);
 }
 
@@ -1714,7 +1724,11 @@ static uint64_t ot_usbdev_read(void *opaque, hwaddr addr, unsigned size)
             val32 = ot_fifo32_pop(&s->rx_fifo);
             trace_ot_usbdev_pop_rx_fifo(s->ot_id, val32);
             ot_usbdev_update_fifos_status(s);
-            /* @todo trigger out transfers potentially */
+            /* Potentially all endpoints are now able to receive some data. */
+            if (ot_fifo32_num_free(&s->rx_fifo) == 1u) {
+                ot_usbdev_update_ep_xfers(s, /* dir_in */ false,
+                                          USBDEV_ALL_EP_MASK);
+            }
         }
         break;
     case R_USBDEV_INTR_TEST:
@@ -1807,7 +1821,11 @@ static void ot_usbdev_write(void *opaque, hwaddr addr, uint64_t val64,
             fifo8_push(&s->av_out_fifo, buf_id);
             trace_ot_usbdev_push_av_out_buffer(s->ot_id, buf_id);
             ot_usbdev_update_fifos_status(s);
-            /* @todo trigger out transfers potentially */
+            /* Potentially all endpoints are now able to receive some data. */
+            if (fifo8_num_used(&s->av_out_fifo) == 1u) {
+                ot_usbdev_update_ep_xfers(s, /* dir_in */ false,
+                                          USBDEV_ALL_EP_MASK);
+            }
         }
         break;
     case R_AVSETUPBUFFER:

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -1498,9 +1498,15 @@ static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
 static void ot_usbdev_write_usbctrl(OtUsbdevState *s, uint32_t val32)
 {
     bool old_enable = ot_usbdev_is_enabled(s);
+    uint8_t old_addr = ot_usbdev_get_address(s);
 
     /* @todo Handle resume_link_active eventually, this is a W/O field */
     s->regs[R_USBCTRL] = val32 & USBDEV_USBCTRL_R_MASK;
+
+    uint8_t new_addr = ot_usbdev_get_address(s);
+    if (old_addr != new_addr) {
+        trace_ot_usbdev_address_changed(s->ot_id, new_addr);
+    }
 
     bool enable = ot_usbdev_is_enabled(s);
     if (enable == old_enable) {

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -531,10 +531,11 @@ struct OtUsbdevState {
     CharBackend usb_chr;
     OtUsbdevServer usb_server;
 
-    /* Timer to handle bus reset. */
+    /*
+     * Timer to handle bus reset. While this timer is pending,
+     * it means that a bus reset signalling is in progress.
+     */
     QEMUTimer bus_reset_timer;
-    /* A bus reset is in progress */
-    bool bus_reset_in_progress;
 
     char *ot_id;
     /* Link to the clkmgr. */
@@ -1054,7 +1055,6 @@ static void ot_usbdev_retire_in_packets(OtUsbdevState *s, uint8_t ep)
 static void ot_usbdev_link_reset_complete(void *opaque)
 {
     OtUsbdevState *s = opaque;
-    s->bus_reset_in_progress = false;
 
     trace_ot_usbdev_link_reset(s->ot_id, true);
 
@@ -1072,7 +1072,9 @@ static void ot_usbdev_link_reset_complete(void *opaque)
 static void ot_usbdev_simulate_link_reset(OtUsbdevState *s)
 {
     g_assert(!resettable_is_in_reset(OBJECT(s)));
-    g_assert(!s->bus_reset_in_progress);
+    error_report(
+        "%s: %s: Simulating a link reset while a bus reset is already pending!",
+        __func__, s->ot_id);
 
     trace_ot_usbdev_link_reset(s->ot_id, false);
 
@@ -1100,7 +1102,6 @@ static void ot_usbdev_simulate_link_reset(OtUsbdevState *s)
      * so we kick a timer to trigger the link state change after the end of
      * signalling.
      */
-    s->bus_reset_in_progress = true;
     int64_t now = qemu_clock_get_ms(OT_VIRTUAL_CLOCK);
     timer_mod(&s->bus_reset_timer, now + USBDEV_BUS_RESET_TIME_MS);
 }
@@ -2390,7 +2391,7 @@ static int ot_usbdev_chr_usb_can_receive(void *opaque)
      * If bus reset signalling is in progress, delay
      * reception until it is done.
      */
-    if (s->bus_reset_in_progress) {
+    if (timer_pending(&s->bus_reset_timer)) {
         return 0;
     }
 
@@ -2566,7 +2567,6 @@ static void ot_usbdev_reset_enter(Object *obj, ResetType type)
      * reset signalling.
      */
     timer_del(&s->bus_reset_timer);
-    s->bus_reset_in_progress = false;
 
     /* See BFM (dut_reset) */
     memset(s->regs, 0u, sizeof(s->regs));

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -539,6 +539,14 @@ struct OtUsbdevState {
      */
     QEMUTimer bus_reset_timer;
 
+    /*
+     * This is the next endpoint that should be considered when
+     * we have pending transfers and we need to choose which
+     * one receives a packet. This is used to provide a weak
+     * form of scheduling and ensure fairness.
+     */
+    uint8_t next_ep_out_sched_xfer;
+
     char *ot_id;
     /* Link to the clkmgr. */
     DeviceState *clock_src;
@@ -1387,8 +1395,11 @@ static void ot_usbdev_advance_transfer_in(OtUsbdevState *s, uint8_t epnum)
  * If a NAK condition is detected (e.g. the host has no transfer pending,
  * or the device has not enabled reception), this
  * function will do nothing.
+ *
+ * Return true if we were able to make progress (receive a packet), false
+ * otherwise.
  */
-static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
+static bool ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
 {
     g_assert(epnum < USBDEV_PARAM_N_ENDPOINTS);
     /* See BFM (out_packet) */
@@ -1397,7 +1408,7 @@ static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
     OtUsbdevServer *server = &s->usb_server;
     OtUsbdevServerEpOutXfer *xfer = &server->ep[epnum].out;
     if (!xfer->pending) {
-        return;
+        return false;
     }
 
     /*
@@ -1407,7 +1418,7 @@ static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
     if (!ot_usbdev_is_ep_out_enabled(s, epnum)) {
         ot_usbdev_complete_transfer_out(s, epnum, OT_USBDEV_SERVER_STATUS_ERROR,
                                         "endpoint OUT not enabled");
-        return;
+        return false;
     }
 
     /* Check for STALL */
@@ -1417,7 +1428,7 @@ static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
                                         "stalled by device");
         s->regs[R_USBDEV_INTR_STATE] |= USBDEV_INTR_LINK_OUT_ERR_MASK;
         ot_usbdev_update_irqs(s);
-        return;
+        return false;
     }
 
     /*
@@ -1432,7 +1443,7 @@ static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
         s->regs[R_USBDEV_INTR_STATE] |= USBDEV_INTR_LINK_OUT_ERR_MASK;
         ot_usbdev_update_irqs(s);
         /* "NAK" packet, OUT transfer will be retried */
-        return;
+        return false;
     }
 
     /* Write data to buffer and update transfer status */
@@ -1468,7 +1479,7 @@ static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
         ot_usbdev_complete_transfer_out(s, epnum,
                                         OT_USBDEV_SERVER_STATUS_SUCCESS,
                                         "success");
-        return;
+        return true;
     }
     if (xfer->send_rem == 0 && xfer->send_zlp) {
         /*
@@ -1478,14 +1489,7 @@ static void ot_usbdev_advance_transfer_out(OtUsbdevState *s, uint8_t epnum)
         xfer->send_zlp = false;
     }
 
-    /*
-     * @todo If the transfer is not complete and RX is still active, we need to
-     * trigger one or more packet reception. However we do not want to do that
-     * in a loop here because it could lead to starvation on other endpoints.
-     * Need to have a timer to do some scheduling.
-     */
-    qemu_log_mask(LOG_UNIMP, "%s: %s: unfinished transfer on EP%u OUT\n",
-                  __func__, s->ot_id, epnum);
+    return true;
 }
 
 /*
@@ -1595,16 +1599,33 @@ static void ot_usbdev_write_configin(OtUsbdevState *s, hwaddr reg,
 static void ot_usbdev_update_ep_xfers(OtUsbdevState *s, bool dir_in,
                                       uint32_t ep_mask)
 {
+    uint8_t last_ep_out_to_progress = 0;
     /* For each disabled ep, update the transfer to trigger an error */
-    for (uint8_t ep = 0u; ep < USBDEV_PARAM_N_ENDPOINTS; ep++) {
+    for (uint8_t _ep = 0u; _ep < USBDEV_PARAM_N_ENDPOINTS; _ep++) {
+        uint8_t ep = _ep;
+        /* For OUT transfers, we do some round-robin scheduling */
+        if (!dir_in) {
+            ep = (_ep + s->next_ep_out_sched_xfer) % USBDEV_PARAM_N_ENDPOINTS;
+        }
+
         if (((ep_mask >> ep) & 1u) == 0u) {
             continue;
         }
         if (dir_in) {
             ot_usbdev_advance_transfer_in(s, ep);
         } else {
-            ot_usbdev_advance_transfer_out(s, ep);
+            if (ot_usbdev_advance_transfer_out(s, ep)) {
+                last_ep_out_to_progress = ep;
+            }
         }
+    }
+    /*
+     * For OUT transfers, set the next endpoint to consider to be the one
+     * right after the last one to make progress.
+     */
+    if (!dir_in) {
+        s->next_ep_out_sched_xfer =
+            (last_ep_out_to_progress + 1u) % USBDEV_PARAM_N_ENDPOINTS;
     }
 }
 

--- a/hw/opentitan/trace-events
+++ b/hw/opentitan/trace-events
@@ -649,6 +649,7 @@ ot_uart_irqs(const char *id, uint32_t active, uint32_t mask, uint32_t eff) "%s: 
 
 # ot_usbdev.c
 
+ot_usbdev_address_changed(const char *id, uint8_t address) "%s: %d"
 ot_usbdev_chr_process_cmd(const char *id, const char *cmd) "%s: %s"
 ot_usbdev_chr_usb_event_handler(const char *id, int event) "%s: server event=%d"
 ot_usbdev_complete_transfer(const char *id, uint32_t cmdid, uint32_t xfered_len, const char *status, const char *msg) "%s: cmdid=%u, len=%u, status=%s: %s"


### PR DESCRIPTION
See commits for more details. This fixes two potentially bugs where OUT transfers may get stuck. It also introduces some form of round-robin scheduling for OUT transfers to avoid starvation. There is also an unrelated change to improve tracing of address changes.

Addresses one of the bullet points of [#28730](https://github.com/lowRISC/opentitan/issues/28730)