### PR TITLE
`ot_usbdev`: emulate frames and add support for transfer cancellation

### DIFF
--- a/docs/opentitan/ot_usbdev.md
+++ b/docs/opentitan/ot_usbdev.md
@@ -131,6 +131,7 @@ The following commands are defined.
 | Setup       |     9     | Host to device | Send a SETUP packet | [Setup command](#setup-command) |
 | Transfer    |    10     | Host to device | Start a transfer | [Transfer command](#transfer-command) |
 | Complete    |    11     | Device to host | Complete a transfer | [Complete command](#complete-command) |
+| Cancel      |    12     | Host to device | Cancel a transfer | [Cancel command](#cancel-command) |
 
 
 
@@ -214,6 +215,15 @@ to the host.
 Sending a `Transfer` command to an endpoint while one is already in progress is an error.
 The device must immediately reply with a `Complete` event with the `Error` status.
 
+#### Cancel command
+
+See [Transfer handling](#transfer-handling) for more details.
+The payload of this command is defined as follows.
+
+| **Field** | **Offset** | **Size** | **Value** |
+| --------- | ---------- | -------- | --------- |
+| Transfer ID |   0      |     4    | ID of the transfer to cancel |
+
 #### Complete command
 
 The ID of this command must be the ID of the corresponding `Transfer` command.
@@ -268,26 +278,43 @@ If the transfer succeeds, the device must send a `Complete` event with the `Succ
 `Size` field indicating how much data was transferred successfully (and for IN transfers, the data
 must be present in the payload).
 
+Upon receiving a `Cancel` command, the device must stop the requested transfer as soon as possible
+and send a `Complete` event with the `Cancel` status. Note that due to the asynchronous nature
+of the protocol, the following sequences of events are possible:
+- the device receives a `Cancel` command for an already completed transfer: the device must ignore
+  the request,
+- the device receives a `Cancel` command for a transfer but the transfer finishes before it can
+  be cancelled: the device must send a `Complete` event, which can either be `Cancelled` or the
+  otherwise normal status of the transfer.
+
 ### Control transfers
 
 The host should first send a `Setup` command at the selected address and endpoint.
 The device does not reply to this command. Note that the USB specification specifies that sending
 a SETUP packet to an endpoint immediately cancels any transaction on this endpoint.
-The device *may* send a `Complete` events for such transfers with the `Cancelled` status.
+The device *may* send `Complete` events for such transfers with the `Cancelled` status.
 
 The rest of the sequence depends on the direction of the transfer:
 - OUT transfers: the host should send one or more `Transfer` commands to the endpoint
-  (with the OUT direction) with the control data.
+  (with the OUT direction) with the control data and the device answers with `Complete` events.
   Once all transfers are complete, the host should send a `Transfer` command to the endpoint
-  with the IN direction and `Size` set to 0.
+  with the IN direction and `Size` set to 0, to which the device answers with a `Complete` event.
 - IN transfers: the host should send one or more `Transfer` commands to the endpoint,
-  (with the IN direction) to receive the control data.
+  (with the IN direction) and the device answers with `Complete` events containing the data.
   Once all transfers are complete, the host should send a `Transfer` command to the endpoint
-  with the OUT direction and `Size` set to 0.
+  with the OUT direction and `Size` set to 0, to which the device answers with a `Complete` event.
 
 ### Bulk and interrupt transfers
 
 TODO
+
+### Cancelling transfers
+
+If the host wishes to cancel a pending transfer, it must send the `Cancel` command with the ID
+of the corresponding `Transfer` command to be cancelled. Due to the asynchronous nature of
+the protocol, it is possible that the transfer successfully completes before the device processes
+the `Cancel` request. Therefore the host *should* wait for a `Complete` event to determine the
+final outcome of the transfer.
 
 ## Note
 

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -66,8 +66,11 @@
 #define OT_USBDEV_MAX_PACKET_SIZE     64u
 #define OT_USBDEV_BUFFER_COUNT        32u
 
-/* Time in milliseconds for a bus reset to complete. */
-#define OT_USBDEV_BUS_RESET_TIME_MS 10u
+/*
+ * Time in microseconds for a bus reset to complete (spec requires at least
+ * 10ms).
+ */
+#define OT_USBDEV_BUS_RESET_TIME_US 10000u
 
 /* Time in microseconds of a frame (fixed by spec). */
 #define OT_USBDEV_FRAME_TIME_US 1000u
@@ -1233,8 +1236,8 @@ static void ot_usbdev_simulate_link_reset(OtUsbdevState *s)
      * so we kick a timer to trigger the link state change after the end of
      * signalling.
      */
-    int64_t now = qemu_clock_get_ms(OT_VIRTUAL_CLOCK);
-    timer_mod(&s->bus_reset_timer, now + OT_USBDEV_BUS_RESET_TIME_MS);
+    int64_t now = qemu_clock_get_us(OT_VIRTUAL_CLOCK);
+    timer_mod(&s->bus_reset_timer, now + OT_USBDEV_BUS_RESET_TIME_US);
 }
 
 /*
@@ -2880,7 +2883,7 @@ static void ot_usbdev_init(Object *obj)
     fifo8_create(&s->av_out_fifo, OT_USBDEV_AV_OUT_FIFO_DEPTH);
     fifo8_create(&s->av_setup_fifo, OT_USBDEV_AV_SETUP_FIFO_DEPTH);
 
-    timer_init_ms(&s->bus_reset_timer, OT_VIRTUAL_CLOCK,
+    timer_init_us(&s->bus_reset_timer, OT_VIRTUAL_CLOCK,
                   &ot_usbdev_link_reset_complete, s);
     timer_init_us(&s->frame_timer, OT_VIRTUAL_CLOCK,
                   &ot_usbdev_frame_timer_expired, s);

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -1018,6 +1018,8 @@ static void ot_usbdev_update_vbus(OtUsbdevState *s)
                 FIELD_DP32(s->regs[R_USBCTRL], USBCTRL, DEVICE_ADDRESS, 0u);
 
             ot_usbdev_cancel_all_transfers(s, "VBUS was disconnected");
+            /* If there is no host then any reset signalling stops. */
+            timer_del(&s->bus_reset_timer);
         }
     }
 
@@ -1082,9 +1084,12 @@ static void ot_usbdev_link_reset_complete(void *opaque)
 static void ot_usbdev_simulate_link_reset(OtUsbdevState *s)
 {
     g_assert(!resettable_is_in_reset(OBJECT(s)));
-    error_report(
-        "%s: %s: Simulating a link reset while a bus reset is already pending!",
-        __func__, s->ot_id);
+    if (timer_pending(&s->bus_reset_timer)) {
+        error_report("%s: %s: Simulating a link reset while a bus reset is "
+                     "already pending!",
+                     __func__, s->ot_id);
+        return;
+    }
 
     trace_ot_usbdev_link_reset(s->ot_id, false);
 

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -67,7 +67,7 @@
 #define OT_USBDEV_BUFFER_COUNT        32u
 
 /* Time in milliseconds for a bus reset to complete. */
-#define USBDEV_BUS_RESET_TIME_MS 10
+#define OT_USBDEV_BUS_RESET_TIME_MS 10u
 
 /* Standard constants */
 #define OT_USBDEV_SETUP_PACKET_SIZE 8u
@@ -1113,7 +1113,7 @@ static void ot_usbdev_simulate_link_reset(OtUsbdevState *s)
      * signalling.
      */
     int64_t now = qemu_clock_get_ms(OT_VIRTUAL_CLOCK);
-    timer_mod(&s->bus_reset_timer, now + USBDEV_BUS_RESET_TIME_MS);
+    timer_mod(&s->bus_reset_timer, now + OT_USBDEV_BUS_RESET_TIME_MS);
 }
 
 /*

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -516,13 +516,19 @@ struct OtUsbdevState {
         MemoryRegion regs;
         MemoryRegion buffer;
     } mmio;
+    char *ot_id;
+    /* Link to the clkmgr. */
+    DeviceState *clock_src;
+    /* Name of the USB clock. */
+    char *usbclk_name;
+    /* Name of the AON clock. */
+    char *aonclk_name;
+
     IbexIRQ irqs[USBDEV_INTR_NUM];
     IbexIRQ alert;
 
     /* Register content */
     uint32_t regs[REGS_COUNT];
-    /* VBUS gate: meaning depends on the vbus_override mode */
-    bool vbus_gate;
 
     /*
      * Content of the RX FIFO: each entry is encoded like the
@@ -596,15 +602,10 @@ struct OtUsbdevState {
      */
     uint8_t next_ep_out_sched_xfer;
 
-    char *ot_id;
-    /* Link to the clkmgr. */
-    DeviceState *clock_src;
-    /* Name of the USB clock. */
-    char *usbclk_name;
-    /* Name of the AON clock. */
-    char *aonclk_name;
     /* VBUS override mode. */
     bool vbus_override;
+    /* VBUS gate: meaning depends on the vbus_override mode */
+    bool vbus_gate;
 };
 
 #define REG_NAME(_reg_) \

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -69,6 +69,9 @@
 /* Time in milliseconds for a bus reset to complete. */
 #define OT_USBDEV_BUS_RESET_TIME_MS 10u
 
+/* Time in microseconds of a frame (fixed by spec). */
+#define OT_USBDEV_FRAME_TIME_US 1000u
+
 /* Standard constants */
 #define OT_USBDEV_SETUP_PACKET_SIZE 8u
 
@@ -538,6 +541,41 @@ struct OtUsbdevState {
      * it means that a bus reset signalling is in progress.
      */
     QEMUTimer bus_reset_timer;
+
+    /*
+     * Timer to handle frame counting. While this timer is pending,
+     * it means that the frame counter must not change and that an
+     * IRQ will be triggered when the timer expires. Also see remarks
+     * on the frame counter.
+     */
+    QEMUTimer frame_timer;
+
+    /*
+     * We keep the current frame number in the following variable. There
+     * are 1000 frames per second so we really want to avoid scheduling a
+     * timer for each frame if we can avoid it. It is very unlikely that
+     * the device will want to do so anyway and it is more likely to read
+     * the frame counter in the USBSTAT register. Therefore we can avoid
+     * using a timer as long as we create a consistent picture for the
+     * device code. This mostly means:
+     * - the frame counter should increase by one every millisecond,
+     * - the frame counter must not change value between two SOF IRQs.
+     * We can keep track of the second condition by noticing that unless
+     * the device code clears the SOF interrupt, it cannot actually detect
+     * when the SOF happens and therefore this consistency check can be
+     * relaxed. However if the device code *does* clear the SOF interrupt,
+     * we need to make sure to enforce the second requirement.
+     *
+     * Therefore the logic is as follows: we record the time at which the bus
+     * reset completed (this is the beginning of "frame 0").
+     * If the frame timer is not pending, we extrapolate the frame counter
+     * value based on the time elapsed since the last bus reset. If the software
+     * clear the SOF interrupt, a frozen value is recorded based on the
+     * previous logic and a frame timer is scheduled. While the frame
+     * timer is pending, the frame counter value is frozen to this value.
+     */
+    uint32_t frozen_frame;
+    int64_t frame0_time_us;
 
     /*
      * This is the next endpoint that should be considered when
@@ -1018,7 +1056,8 @@ static void ot_usbdev_update_vbus(OtUsbdevState *s)
                 FIELD_DP32(s->regs[R_USBCTRL], USBCTRL, DEVICE_ADDRESS, 0u);
 
             ot_usbdev_cancel_all_transfers(s, "VBUS was disconnected");
-            /* If there is no host then any reset signalling stops. */
+            /* If there is no host then any SOF or reset signalling stops. */
+            timer_del(&s->frame_timer);
             timer_del(&s->bus_reset_timer);
         }
     }
@@ -1060,6 +1099,65 @@ static void ot_usbdev_retire_in_packets(OtUsbdevState *s, uint8_t ep)
     s->regs[R_CONFIGIN_0 + ep] = configin;
 }
 
+static uint32_t ot_usbdev_get_frame(OtUsbdevState *s)
+{
+    /*
+     * See logic in the documentation of the OtUsbdevState struct:
+     * - if frame timer is pending, value is frozen
+     * - otherwise, extrapolate based on time
+     */
+    if (timer_pending(&s->frame_timer)) {
+        return s->frozen_frame;
+    }
+    int64_t time_us = qemu_clock_get_us(OT_VIRTUAL_CLOCK);
+    return (uint32_t)(time_us - s->frame0_time_us) / OT_USBDEV_FRAME_TIME_US;
+}
+
+/*
+ * Callback to simulate a start of frame. The timer is only started
+ * when needed (i.e. on bus reset complete and when the device expects
+ * an interrupt).
+ */
+static void ot_usbdev_frame_timer_expired(void *opaque)
+{
+    OtUsbdevState *s = opaque;
+
+    /*
+     * If this is the first SOF after a bus reset, we need to change the link
+     * state.
+     */
+    if (ot_usbdev_get_link_state(s) == OT_USBDEV_LINK_STATE_ACTIVE_NOSOF) {
+        ot_usbdev_set_raw_link_state(s, OT_USBDEV_LINK_STATE_ACTIVE);
+    } else if (ot_usbdev_get_link_state(s) != OT_USBDEV_LINK_STATE_ACTIVE) {
+        /*
+         * The following should not happen but if for some reason we are
+         * not in the active state, ignore.
+         */
+        error_report("%s: %s: SOF timer expired in a non-active state",
+                     __func__, s->ot_id);
+        return;
+    }
+
+    /* Set frame interrupt. */
+    s->regs[R_USBDEV_INTR_STATE] |= USBDEV_INTR_FRAME_MASK;
+    ot_usbdev_update_irqs(s);
+}
+
+/* Schedule a frame timer for the next frame. */
+static void ot_usbdev_schedule_frame_timer(OtUsbdevState *s)
+{
+    /* Do not schedule one if one is pending. */
+    if (timer_pending(&s->frame_timer)) {
+        return;
+    }
+
+    uint32_t cur_frame = ot_usbdev_get_frame(s);
+    /* Find the time at which the next frame will start. */
+    int64_t next_frame_time_us =
+        s->frame0_time_us + (cur_frame + 1u) * OT_USBDEV_FRAME_TIME_US;
+    timer_mod(&s->frame_timer, next_frame_time_us);
+}
+
 /*
  * Callback to notify bus reset completion. The timer is started
  * in ot_usbdev_simulate_link_reset.
@@ -1072,6 +1170,13 @@ static void ot_usbdev_link_reset_complete(void *opaque)
 
     if (ot_usbdev_has_vbus(s) && ot_usbdev_is_enabled(s)) {
         ot_usbdev_set_raw_link_state(s, OT_USBDEV_LINK_STATE_ACTIVE_NOSOF);
+        /*
+         * Record "frame 0 timer" and schedule a timer for frame 1.
+         * We need the timer so that it changes the link state to active.
+         */
+        s->frame0_time_us = qemu_clock_get_us(OT_VIRTUAL_CLOCK);
+        s->frozen_frame = 0u;
+        ot_usbdev_schedule_frame_timer(s);
     }
 }
 
@@ -1111,6 +1216,9 @@ static void ot_usbdev_simulate_link_reset(OtUsbdevState *s)
         ot_usbdev_retire_in_packets(s, ep);
     }
     ot_usbdev_cancel_all_transfers(s, "cancelled by link reset");
+
+    /* Stop any frame timer pending. */
+    timer_del(&s->frame_timer);
 
     /*
      * On real hardware, reset signalling typically takes several milliseconds
@@ -1699,7 +1807,6 @@ static uint64_t ot_usbdev_read(void *opaque, hwaddr addr, unsigned size)
     switch (reg) {
     /* Reads with no side-effects */
     case R_PHY_CONFIG:
-    case R_USBSTAT:
     case R_USBDEV_INTR_STATE:
     case R_USBDEV_INTR_ENABLE:
     case R_USBCTRL:
@@ -1739,6 +1846,17 @@ static uint64_t ot_usbdev_read(void *opaque, hwaddr addr, unsigned size)
     case R_COUNT_NODATA_IN:
     case R_COUNT_ERRORS:
         val32 = s->regs[reg];
+        break;
+    case R_USBSTAT:
+        /*
+         * We extrapolate the frame counter on each read to avoid frequent
+         * updates. Note that the field in the register can wrap around but we
+         * internally keep track of the frame counter with all bits, so the
+         * following code will truncate the value which is the correct
+         * behaviour.
+         */
+        val32 =
+            FIELD_DP32(s->regs[reg], USBSTAT, FRAME, ot_usbdev_get_frame(s));
         break;
     case R_RXFIFO:
         if (ot_fifo32_is_empty(&s->rx_fifo)) {
@@ -1794,6 +1912,20 @@ static void ot_usbdev_write(void *opaque, hwaddr addr, uint64_t val64,
     switch (reg) {
     case R_USBDEV_INTR_STATE:
         val32 &= USBDEV_INTR_RW1C_MASK;
+        /*
+         * If the frame interrupt state was previously not clear and now becomes
+         * cleared, it means that the device will now be able to observe when
+         * the next SOF arrives. Inbetween now and that time, we must ensure
+         * that the frame counter stays frozen. See explanation in OtUsbdevState
+         * struct.
+         */
+        if ((s->regs[reg] & USBDEV_INTR_FRAME_MASK) != 0u &&
+            (val32 & USBDEV_INTR_FRAME_MASK) != 0u) {
+            s->frozen_frame = ot_usbdev_get_frame(s);
+            /* Schedule a frame timer to unfreeze. This is a no-op if one is
+             * already pending. */
+            ot_usbdev_schedule_frame_timer(s);
+        }
         s->regs[reg] &= ~val32;
         ot_usbdev_update_irqs(s);
         break;
@@ -2609,8 +2741,9 @@ static void ot_usbdev_reset_enter(Object *obj, ResetType type)
      * The rationale is that on a real bus, the device
      * reset would cause the block to disable the pullup
      * so the host would notice the disconnection and stop
-     * reset signalling.
+     * reset signalling. The same applies for the frame timer.
      */
+    timer_del(&s->frame_timer);
     timer_del(&s->bus_reset_timer);
 
     /* See BFM (dut_reset) */
@@ -2691,6 +2824,8 @@ static void ot_usbdev_init(Object *obj)
 
     timer_init_ms(&s->bus_reset_timer, OT_VIRTUAL_CLOCK,
                   &ot_usbdev_link_reset_complete, s);
+    timer_init_us(&s->frame_timer, OT_VIRTUAL_CLOCK,
+                  &ot_usbdev_frame_timer_expired, s);
 }
 
 static void ot_usbdev_class_init(ObjectClass *klass, void *data)

--- a/hw/opentitan/ot_usbdev.c
+++ b/hw/opentitan/ot_usbdev.c
@@ -362,6 +362,7 @@ typedef enum {
     OT_USBDEV_SERVER_CMD_SETUP,
     OT_USBDEV_SERVER_CMD_TRANSFER,
     OT_USBDEV_SERVER_CMD_COMPLETE,
+    OT_USBDEV_SERVER_CMD_CANCEL,
 } OtUsbdevServerCmd;
 
 typedef struct {
@@ -421,6 +422,13 @@ typedef enum {
     OT_USBDEV_SERVER_STATUS_CANCELLED,
     OT_USBDEV_SERVER_STATUS_ERROR,
 } OtUsbdevServerTransferStatus;
+
+typedef struct {
+    uint32_t xfer_id;
+} OtUsbdevServerCancelPkt;
+
+static_assert(sizeof(OtUsbdevServerCancelPkt) == 4u,
+              "Cancel packet has the wrong size");
 
 #define XFER_STATUS_ENTRY(_name) \
     [OT_USBDEV_SERVER_STATUS_##_name] = stringify(_name)
@@ -1394,6 +1402,32 @@ void ot_usbdev_cancel_all_transfers(OtUsbdevState *s, const char *reason)
                                         OT_USBDEV_SERVER_STATUS_CANCELLED,
                                         reason);
     }
+}
+
+/*
+ * Cancel a specific transfer by ID.
+ * Return true if a matching transfer was found, and false otherwise.
+ */
+static bool ot_usbdev_cancel_transfer_by_id(OtUsbdevState *s, uint32_t xfer_id,
+                                            const char *reason)
+{
+    OtUsbdevServer *server = &s->usb_server;
+
+    for (unsigned ep = 0; ep < USBDEV_PARAM_N_ENDPOINTS; ep++) {
+        if (server->ep[ep].in.pending && server->ep[ep].in.id == xfer_id) {
+            ot_usbdev_complete_transfer_in(s, ep,
+                                           OT_USBDEV_SERVER_STATUS_CANCELLED,
+                                           reason);
+            return true;
+        }
+        if (server->ep[ep].out.pending && server->ep[ep].out.id == xfer_id) {
+            ot_usbdev_complete_transfer_out(s, ep,
+                                            OT_USBDEV_SERVER_STATUS_CANCELLED,
+                                            reason);
+            return true;
+        }
+    }
+    return false;
 }
 
 /*
@@ -2486,6 +2520,27 @@ static void ot_usbdev_server_process_transfer(OtUsbdevState *s)
     }
 }
 
+static void ot_usbdev_server_process_cancel(OtUsbdevState *s)
+{
+    OtUsbdevServer *server = &s->usb_server;
+
+    if (server->recv_pkt.size != sizeof(OtUsbdevServerCancelPkt)) {
+        trace_ot_usbdev_server_protocol_error(
+            s->ot_id, "CANCEL packet with unexpected payload size, "
+                      "ignoring packet");
+        return;
+    }
+
+    OtUsbdevServerCancelPkt xfer;
+    memcpy(&xfer, server->recv_data, sizeof(OtUsbdevServerCancelPkt));
+
+    bool success = ot_usbdev_cancel_transfer_by_id(s, xfer.xfer_id,
+                                                   "Cancelled by request");
+
+    trace_ot_usbdev_cancel(s->ot_id, xfer.xfer_id,
+                           success ? "success" : "no matching transfer found");
+}
+
 static void ot_usbdev_server_process_packet(OtUsbdevState *s)
 {
     OtUsbdevServer *server = &s->usb_server;
@@ -2524,6 +2579,9 @@ static void ot_usbdev_server_process_packet(OtUsbdevState *s)
         break;
     case OT_USBDEV_SERVER_CMD_TRANSFER:
         ot_usbdev_server_process_transfer(s);
+        break;
+    case OT_USBDEV_SERVER_CMD_CANCEL:
+        ot_usbdev_server_process_cancel(s);
         break;
     default:
         trace_ot_usbdev_server_protocol_error(

--- a/hw/opentitan/trace-events
+++ b/hw/opentitan/trace-events
@@ -652,6 +652,7 @@ ot_uart_irqs(const char *id, uint32_t active, uint32_t mask, uint32_t eff) "%s: 
 ot_usbdev_address_changed(const char *id, uint8_t address) "%s: %d"
 ot_usbdev_chr_process_cmd(const char *id, const char *cmd) "%s: %s"
 ot_usbdev_chr_usb_event_handler(const char *id, int event) "%s: server event=%d"
+ot_usbdev_cancel(const char *id, uint32_t xfer_id, const char *msg) "%s: xfer_id=%u: %s"
 ot_usbdev_complete_transfer(const char *id, uint32_t cmdid, uint32_t xfered_len, const char *status, const char *msg) "%s: cmdid=%u, len=%u, status=%s: %s"
 ot_usbdev_enable_changed(const char *id, bool enable) "%s: enable=%u"
 ot_usbdev_io_buffer_read_out(const char *id, uint32_t addr, uint32_t val, uint32_t pc) "%s: addr=0x%04x, val=0x%x, pc=0x%x"


### PR DESCRIPTION
See individual commits for details. Fixes [#28730](https://github.com/lowRISC/opentitan/issues/28730)