### PR TITLE
`ot_spi_host`: use an IP version to select emulation

### DIFF
--- a/hw/opentitan/ot_clkmgr.c
+++ b/hw/opentitan/ot_clkmgr.c
@@ -770,7 +770,7 @@ static unsigned ot_clkmgr_parse_hint(OtClkMgrState *s, Error **errp)
     unsigned hint_count = 0;
 
     if (!s->cfg_hint) {
-        error_setg(errp, "%s: hintabkle clocks not defined", __func__);
+        error_setg(errp, "%s: hintable clocks not defined", __func__);
         return hint_count;
     }
 

--- a/hw/opentitan/ot_pwrmgr.c
+++ b/hw/opentitan/ot_pwrmgr.c
@@ -337,7 +337,7 @@ static const OtPwrMgrConfig PWRMGR_CONFIG[OT_PWRMGR_VERSION_COUNT] = {
         .control_mask = 0x1f1u,
         .control_res_val = 0x180u, /* MAIN_PD_N | USB_CLK_EN_ACTIVE */
     },
-    [OT_PWRMGR_VERSION_DJ_PRE] = {
+    [OT_PWRMGR_VERSION_DJ] = {
         .wakeup_count = 4u,
         .reset_count = 2u,
         .reset_mask = 0x3u,
@@ -367,7 +367,7 @@ PWRMGR_RESET_DISPATCH[OT_PWRMGR_VERSION_COUNT][PWRMGR_RST_REQ_MAX] = {
         [0] = OT_RSTMGR_RESET_SYSCTRL,
         [1] = OT_RSTMGR_RESET_AON_TIMER,
     },
-    [OT_PWRMGR_VERSION_DJ_PRE] = {
+    [OT_PWRMGR_VERSION_DJ] = {
         [0] = OT_RSTMGR_RESET_AON_TIMER,
         [1] = OT_RSTMGR_RESET_SOC_PROXY,
     },
@@ -383,7 +383,7 @@ PWRMGR_WAKEUP_NAMES[OT_PWRMGR_VERSION_COUNT][PWRMGR_WAKEUP_MAX] = {
         [4] = "AON_TIMER",
         [5] = "SENSOR",
     },
-    [OT_PWRMGR_VERSION_DJ_PRE] = {
+    [OT_PWRMGR_VERSION_DJ] = {
         [0] = "PINMUX",
         [1] = "USBDEV",
         [2] = "AON_TIMER",
@@ -399,7 +399,7 @@ PWRMGR_RST_NAMES[OT_PWRMGR_VERSION_COUNT][PWRMGR_RST_REQ_MAX] = {
         [0] = "SYSRST",
         [1] = "AON_TIMER",
     },
-    [OT_PWRMGR_VERSION_DJ_PRE] = {
+    [OT_PWRMGR_VERSION_DJ] = {
         [0] = "AON_TIMER",
         [1] = "SOC_PROXY",
     }

--- a/hw/opentitan/ot_rstmgr.c
+++ b/hw/opentitan/ot_rstmgr.c
@@ -226,7 +226,7 @@ static const OtRstMgrConfig RSTMGR_CONFIG[OT_RSTMGR_VERSION_COUNT] = {
              */
         }
     },
-    [OT_RSTMGR_VERSION_DJ_PRE] = {
+    [OT_RSTMGR_VERSION_DJ] = {
         .reset_request_codes = {
             [OT_RSTMGR_RESET_POR] = BIT(0),
             [OT_RSTMGR_RESET_LOW_POWER] = BIT(1),

--- a/hw/opentitan/ot_spi_host.c
+++ b/hw/opentitan/ot_spi_host.c
@@ -109,16 +109,16 @@ REG32(CONFIGOPTS, 0x18u)
 REG32(CSID, 0x1cu)
     FIELD(CSID, CSID, 0u, 32u)
 REG32(COMMAND, 0x20u)
-/* Darjeeling field definitions */
+/* v3 field definitions */
     FIELD(COMMAND, CSAAT, 0u, 1u)
     FIELD(COMMAND, SPEED, 1u, 2u)
     FIELD(COMMAND, DIRECTION, 3u, 2u)
     FIELD(COMMAND, LEN, 5u, 20u)
-/* Earlgrey 1.0.0 field definitions */
-    FIELD(COMMAND, EG_1_0_0_LEN, 0u, 9u)
-    FIELD(COMMAND, EG_1_0_0_CSAAT, 9u, 1u)
-    FIELD(COMMAND, EG_1_0_0_SPEED, 10u, 2u)
-    FIELD(COMMAND, EG_1_0_0_DIRECTION, 12u, 2u)
+/* v2 field definitions */
+    FIELD(COMMAND, V2_LEN, 0u, 9u)
+    FIELD(COMMAND, V2_CSAAT, 9u, 1u)
+    FIELD(COMMAND, V2_SPEED, 10u, 2u)
+    FIELD(COMMAND, V2_DIRECTION, 12u, 2u)
 REG32(RXDATA, 0x24u)
 REG32(TXDATA, 0x28u)
 REG32(ERROR_ENABLE, 0x2cu)
@@ -373,7 +373,7 @@ struct OtSPIHostState {
     uint32_t completion_delay_ns; /** completion delay/pacing */
     uint32_t bus_num; /* SPI host port number */
     uint32_t num_cs; /* Supported CS line count */
-    uint8_t version;
+    uint8_t version; /* HW version */
 };
 
 /* ------------------------------------------------------------------------ */
@@ -500,12 +500,12 @@ static uint32_t cmdfifo_num_used(const CmdFifo *fifo)
 /* Helpers */
 /* ------------------------------------------------------------------------ */
 
-static uint32_t ot_spi_host_convert_from_eg_1_0_0_command(uint32_t eg_cmd)
+static uint32_t ot_spi_host_convert_from_c2_command(uint32_t eg_cmd)
 {
-    uint32_t csaat = FIELD_EX32(eg_cmd, COMMAND, EG_1_0_0_CSAAT);
-    uint32_t speed = FIELD_EX32(eg_cmd, COMMAND, EG_1_0_0_SPEED);
-    uint32_t direction = FIELD_EX32(eg_cmd, COMMAND, EG_1_0_0_DIRECTION);
-    uint32_t len = FIELD_EX32(eg_cmd, COMMAND, EG_1_0_0_LEN);
+    uint32_t csaat = FIELD_EX32(eg_cmd, COMMAND, V2_CSAAT);
+    uint32_t speed = FIELD_EX32(eg_cmd, COMMAND, V2_SPEED);
+    uint32_t direction = FIELD_EX32(eg_cmd, COMMAND, V2_DIRECTION);
+    uint32_t len = FIELD_EX32(eg_cmd, COMMAND, V2_LEN);
 
     /* EG 1.0.0 has a narrower length field, so this conversion is safe. */
     uint32_t cmd = 0;
@@ -1210,9 +1210,9 @@ static void ot_spi_host_io_write(void *opaque, hwaddr addr, uint64_t val64,
         s->regs[reg] = val32;
         break;
     case R_COMMAND: {
-        /* Convert command for back-compat with Earlgrey 1.0.0 fields */
-        if (s->version == OT_SPI_HOST_VERSION_EG_1_0_0) {
-            val32 = ot_spi_host_convert_from_eg_1_0_0_command(val32);
+        /* Convert command for back-compat with v2 fields */
+        if (s->version == 2u) {
+            val32 = ot_spi_host_convert_from_c2_command(val32);
         }
         val32 &= R_COMMAND_MASK;
 
@@ -1447,7 +1447,7 @@ static Property ot_spi_host_properties[] = {
                        FSM_START_DELAY_NS),
     DEFINE_PROP_UINT32("completion-delay", OtSPIHostState, completion_delay_ns,
                        0),
-    DEFINE_PROP_UINT8("version", OtSPIHostState, version, UINT8_MAX),
+    DEFINE_PROP_UINT8("version", OtSPIHostState, version, 0),
     DEFINE_PROP_END_OF_LIST(),
 };
 
@@ -1513,7 +1513,7 @@ static void ot_spi_host_realize(DeviceState *dev, Error **errp)
     g_assert(s->clock_src);
     OBJECT_CHECK(IbexClockSrcIf, s->clock_src, TYPE_IBEX_CLOCK_SRC_IF);
 
-    g_assert(s->version < OT_SPI_HOST_VERSION_COUNT);
+    g_assert(s->version > 1u); /* only supports v2 onward */
 
     s->cs_lines = g_new0(IbexIRQ, (size_t)s->num_cs);
 

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1367,7 +1367,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         .prop = IBEXDEVICEPROPDEFS(
             IBEX_DEV_STRING_PROP("clocks", "main,io"),
             IBEX_DEV_UINT_PROP("num-rom", 2u),
-            IBEX_DEV_UINT_PROP("version", OT_PWRMGR_VERSION_DJ_PRE)
+            IBEX_DEV_UINT_PROP("version", OT_PWRMGR_VERSION_DJ)
         ),
     },
     [OT_DJ_SOC_DEV_RSTMGR] = {
@@ -1382,7 +1382,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
                              OT_PWRMGR_SW_RST, 0)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_UINT_PROP("version", OT_RSTMGR_VERSION_DJ_PRE)
+            IBEX_DEV_UINT_PROP("version", OT_RSTMGR_VERSION_DJ)
         ),
     },
     [OT_DJ_SOC_DEV_CLKMGR] = {
@@ -1412,7 +1412,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
                 "timers:aon+io_div4"),
             IBEX_DEV_STRING_PROP("swcg", "peri"),
             IBEX_DEV_STRING_PROP("hint", "trans"),
-            IBEX_DEV_UINT_PROP("version", OT_CLKMGR_VERSION_DJ_PRE)
+            IBEX_DEV_UINT_PROP("version", OT_CLKMGR_VERSION_DJ)
         ),
     },
     [OT_DJ_SOC_DEV_PINMUX] = {

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1316,7 +1316,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "spi0"),
             IBEX_DEV_UINT_PROP("bus-num", 0),
             IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4"),
-            IBEX_DEV_UINT_PROP("version", OT_SPI_HOST_VERSION_DJ_PRE)
+            IBEX_DEV_UINT_PROP("version", 3u)
         ),
     },
     [OT_DJ_SOC_DEV_SPI_DEVICE] = {

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -901,7 +901,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "spi0"),
             IBEX_DEV_UINT_PROP("bus-num", 0),
             IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4"),
-            IBEX_DEV_UINT_PROP("version", OT_SPI_HOST_VERSION_EG_1_0_0)
+            IBEX_DEV_UINT_PROP("version", 2u)
         ),
     },
     [OT_EG_SOC_DEV_SPI_HOST1] = {
@@ -922,7 +922,7 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
             IBEX_DEV_STRING_PROP(OT_COMMON_DEV_ID, "spi1"),
             IBEX_DEV_UINT_PROP("bus-num", 1),
             IBEX_DEV_STRING_PROP("clock-name", "peri.io_div4"),
-            IBEX_DEV_UINT_PROP("version", OT_SPI_HOST_VERSION_EG_1_0_0)
+            IBEX_DEV_UINT_PROP("version", 2u)
         ),
     },
     [OT_EG_SOC_DEV_USBDEV] = {

--- a/include/hw/opentitan/ot_clkmgr.h
+++ b/include/hw/opentitan/ot_clkmgr.h
@@ -36,7 +36,7 @@ OBJECT_DECLARE_TYPE(OtClkMgrState, OtClkMgrClass, OT_CLKMGR)
 /* Supported ClockManager versions */
 typedef enum {
     OT_CLKMGR_VERSION_EG_1_0_0,
-    OT_CLKMGR_VERSION_DJ_PRE,
+    OT_CLKMGR_VERSION_DJ,
     OT_CLKMGR_VERSION_COUNT,
 } OtClkMgrVersion;
 

--- a/include/hw/opentitan/ot_pwrmgr.h
+++ b/include/hw/opentitan/ot_pwrmgr.h
@@ -37,7 +37,7 @@ OBJECT_DECLARE_TYPE(OtPwrMgrState, OtPwrMgrClass, OT_PWRMGR)
 /* Supported PowerManager versions */
 typedef enum {
     OT_PWRMGR_VERSION_EG_1_0_0,
-    OT_PWRMGR_VERSION_DJ_PRE,
+    OT_PWRMGR_VERSION_DJ,
     OT_PWRMGR_VERSION_COUNT,
 } OtPwrMgrVersion;
 

--- a/include/hw/opentitan/ot_rstmgr.h
+++ b/include/hw/opentitan/ot_rstmgr.h
@@ -36,7 +36,7 @@ OBJECT_DECLARE_TYPE(OtRstMgrState, OtRstMgrClass, OT_RSTMGR)
 /* Supported ResetManager versions */
 typedef enum {
     OT_RSTMGR_VERSION_EG_1_0_0,
-    OT_RSTMGR_VERSION_DJ_PRE,
+    OT_RSTMGR_VERSION_DJ,
     OT_RSTMGR_VERSION_COUNT,
 } OtRstMgrVersion;
 

--- a/include/hw/opentitan/ot_spi_host.h
+++ b/include/hw/opentitan/ot_spi_host.h
@@ -61,11 +61,4 @@ struct OtSPIHostClass {
 #define OT_SPI_HOST_PASSTHROUGH_EN (TYPE_OT_SPI_HOST "-passthrough-en")
 #define OT_SPI_HOST_PASSTHROUGH_CS (TYPE_OT_SPI_HOST "-passthrough-cs")
 
-/* Supported SPI Host versions */
-typedef enum {
-    OT_SPI_HOST_VERSION_EG_1_0_0,
-    OT_SPI_HOST_VERSION_DJ_PRE,
-    OT_SPI_HOST_VERSION_COUNT,
-} OtSPIHostVersion;
-
 #endif /* HW_OPENTITAN_OT_SPI_HOST_H */


### PR DESCRIPTION
SPI host behavior/features are not tied to a peculiar Top version, but to an IP version.

Also remove the _PRE suffix from top-specific emulated IPs, since this reflects a very old version of Darjeeling, not the current master.
