### PR TITLE
`tools`: rewrite swexit.py to use DV SIM window

### DIFF
--- a/scripts/opentitan/swexit.py
+++ b/scripts/opentitan/swexit.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2023-2024 Rivos, Inc.
+# Copyright (c) 2023-2025 Rivos, Inc.
 # SPDX-License-Identifier: Apache2
 
 """OpenTitan exit code generator for QEMU.
+
+   Generate a small RV32I instruction bytestream to instruct the Ibex core to
+   trigger a VM shutdown, using a dedicated HW register.
+
+   This generator avoids adding a dependency on a RISC-V toolchain for the sake
+   of smoke-testing an Ibex/OpenTitan VM.
 
    :author: Emmanuel Blot <eblot@rivosinc.com>
 """
@@ -14,44 +20,135 @@ from traceback import format_exc
 from typing import Union
 import sys
 
-# pylint: disable=missing-function-docstring
 
-BASE_ADDRESS = {
-    'earlgrey': 0x411f0000,
-    'darjeeling': 0x211f0000,
-    'ibexdemo': 0x20000,
+SOC_CONSTANTS = {
+    'earlgrey': (0x411f0000, 0x80),
+    'darjeeling': (0x211f0000, 0x440),
+    'ibexdemo': (0x20000, None)
 }
+"""Supported SoCs, with controller base address and register offset."""
 
-LUI_MASK = (1 << 12) - 1
+TEST_STATUS_PASSED = 0x900d  # 'good'
+"""Special code to signal a successful completion to DV SIM register."""
+
+OPCODE = {
+    'addi': 0b000_00000_0010011,
+    'lui': 0b0110111,
+    'srli': 0b101_00000_0010011,
+    'ssli': 0b001_00000_0010011,
+    'sw':  0b010_00000_0100011,
+    'wfi': 0x10500073,
+}
+"""RV32I binary opcodes used in code generator."""
 
 
 def to_int(value: Union[int, str]) -> int:
+    """Argparser helper to parse decimal or hexadecimal integer strings."""
     if isinstance(value, int):
         return value
     return int(value.strip(), value.startswith('0x') and 16 or 10)
 
 
-def opentitan_code(addr: int) -> bytes:
-    addr &= ~LUI_MASK
-    lui = addr | 0x537
-    return spack('<IIII',
-                 lui,         # lui  a0,addr     # ibex_core_wrapper base
-                 0xc0de05b7,  # lui  a1,0xc0de0  # exit code (0)
-                 0x00b52423,  # sw   a1,8(a0)    # write to sw_fatal_err
-                 0x10500073)  # wfi              # stop here
+def rd_u(reg: int) -> int:
+    """Destination register for U-type instruction."""
+    return reg << 7
+
+
+def imm_u(imm: int) -> int:
+    """Immediate value for U-type instruction."""
+    return imm << 12
+
+
+def mask_u(imm: int) -> int:
+    """Mask immediate value for U-type instruction."""
+    return imm & ~((1 << 12) - 1)
+
+
+def imm_i(imm: int) -> int:
+    """Immediate value for I-type instruction."""
+    return imm << 20
+
+
+def rs1_i(reg: int) -> int:
+    """Source register for I-type instruction."""
+    return reg << 15
+
+
+def rd_i(reg: int) -> int:
+    """Destination register for I-type instruction."""
+    return reg << 7
+
+
+def shamt_i(imm: int) -> int:
+    """Shift ammount for I-type instruction."""
+    return imm << 20
+
+
+def rs1_s(reg: int) -> int:
+    """First source register for S-type instruction."""
+    return reg << 15
+
+
+def rs2_s(reg: int) -> int:
+    """Second source register for S-type instruction."""
+    return reg << 20
+
+
+def off_s(imm: int) -> int:
+    """Offset value for S-type instruction."""
+    off_hi = (imm >> 5) << 25
+    off_lo = (imm & 0b11111) << 7
+    return off_hi | off_lo
+
+
+def opentitan_code(addr: int, offset: int) -> bytes:
+    """Exit code generation using DV SIM status register.
+
+       :param addr: Ibex wrapper controller base address
+       :param offset: Offset of the DV SIM status register.
+       :return: RV32I instruction stream
+    """
+    assert 0 <= offset < (1 << 11)  # 12 bit, signed int
+    instructions = [
+        # lui  a0,addr       # ibex_core_wrapper base
+        mask_u(addr) | rd_u(10) | OPCODE['lui'],
+        # lui  a1,status     # "test" status
+        imm_u(TEST_STATUS_PASSED) | rd_u(11) | OPCODE['lui'],
+        # srli a1,a1,12      # shift down status
+        shamt_i(12) | rs1_i(11) | rd_i(11) | OPCODE['srli'],
+        # sw   a1,offset(a0) # write to DV SIM offset
+        off_s(offset) | rs2_s(11) | rs1_s(10) | OPCODE['sw'],
+        # wfi                # stop here
+        OPCODE['wfi'],
+        # illegal instruction
+        0x0
+    ]
+    return spack(f'<{len(instructions)}I', *instructions)
 
 
 def ibexdemo_code(addr: int) -> bytes:
-    addr &= ~LUI_MASK
-    lui = addr | 0x537
-    return spack('<IIII',
-                 lui,         # lui  a0,addr     # simulator_ctrl base
-                 0x00100593,  # li   a1,1        # set bit 0 to exit
-                 0x00b52423,  # sw   a1,8(a0)    # write to sim_ctrl
-                 0x10500073)  # wfi              # stop here
+    """Exit code generation for Ibex demo machine.
+
+       :param addr: Controller base address
+       :return: RV32I instruction stream
+    """
+    instructions = [
+        # lui  a0,addr       # simulator_ctrl base
+        mask_u(addr) | rd_u(10) | OPCODE['lui'],
+        # li   a1,1          # set bit 0 to exit
+        imm_i(1) | rs1_i(0) | rd_i(11) | OPCODE['addi'],
+        # sw   a1,offset(a0) # write to DV SIM offset
+        off_s(0x8) | rs2_s(11) | rs1_s(10) | OPCODE['sw'],
+        # wfi                # stop here
+        OPCODE['wfi'],
+        # illegal instruction
+        0x0
+    ]
+    return spack(f'<{len(instructions)}I', *instructions)
 
 
 def main():
+    """Entry point."""
     debug = False
     try:
         desc = sys.modules[__name__].__doc__.split('.', 1)[0].strip()
@@ -62,7 +159,7 @@ def main():
         argparser.add_argument('-b', '--base', type=to_int, default=0x80,
                                help='Offset for the first instruction '
                                     '(default: 0x80)')
-        argparser.add_argument('-t', '--soc', choices=list(BASE_ADDRESS),
+        argparser.add_argument('-t', '--soc', choices=list(SOC_CONSTANTS),
                                help='SoC type', required=True)
         argparser.add_argument('-o', '--output', type=FileType('wb'),
                                help='output file, default to stdout')
@@ -71,11 +168,14 @@ def main():
         args = argparser.parse_args()
         debug = args.debug
 
-        addr = args.address if args.address else BASE_ADDRESS[args.soc]
+        addr = args.address if args.address else SOC_CONSTANTS[args.soc][0]
         if args.soc == 'ibexdemo':
             bincode = ibexdemo_code(addr)
         else:
-            bincode = opentitan_code(addr)
+            offset = SOC_CONSTANTS.get(args.soc)[1]
+            if offset is None:
+                argparser.error('Unsupported SoC type')
+            bincode = opentitan_code(addr, offset)
         out = args.output or sys.stdout.buffer
         padding = bytes(args.base)
         out.write(padding)


### PR DESCRIPTION
`rv_core_ibex.SW_FATAL_ERR` has been deprecated a long time ago, however this smoke test generator had not been updated.

See 7ba08ffa2372023eaf09764495e3556468b9075a