### PR TITLE
`ot_darjeeling, ot_earlgrey`: remove hard-coded clock definitions

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -50,6 +50,7 @@ jobs:
           path: |
             build-clang/qemu-system-riscv32
             build-clang/exit_*.bin
+            docs/config/opentitan/*.cfg
           retention-days: 1
       - name: Pack source artifacts
         # GitHub takes ages to retrieve each source file, so pack them
@@ -150,24 +151,26 @@ jobs:
           name: qemu-bin
       - name: Check machine availability
         run: |
-          chmod +x ./qemu-system-riscv32 &&
-          ./qemu-system-riscv32 -M help | grep ibexdemo &&
-          ./qemu-system-riscv32 -M help | grep ot-earlgrey &&
-          ./qemu-system-riscv32 -M help | grep ot-darjeeling
+          chmod +x build-clang/qemu-system-riscv32 &&
+          build-clang/qemu-system-riscv32 -M help | grep ibexdemo &&
+          build-clang/qemu-system-riscv32 -M help | grep ot-earlgrey &&
+          build-clang/qemu-system-riscv32 -M help | grep ot-darjeeling
       - name: Check IbexDemo VM execution
         run: |
-          timeout -s KILL 4 ./qemu-system-riscv32 -M ibexdemo -nographic \
-            -device loader,addr=0x100080,file=exit_id.bin -d in_asm,int
+          timeout -s KILL 4 build-clang/qemu-system-riscv32 -M ibexdemo -nographic \
+            -device loader,addr=0x100080,file=build-clang/exit_id.bin -d in_asm,int
       - name: Check EarlGrey VM execution
         run: |
-          timeout -s KILL 4 ./qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -nographic \
-            -object ot-rom_img,id=rom,file=exit_eg.bin -global ot-ibex_wrapper.lc-ignore=on \
-            -d in_asm,int
+          timeout -s KILL 4 build-clang/qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -nographic \
+            -object ot-rom_img,id=rom,file=build-clang/exit_eg.bin -global ot-ibex_wrapper.lc-ignore=on \
+            -readconfig docs/config/opentitan/earlgrey.cfg -d in_asm,int \
+            -trace ot_ibex_wrapper_exit
       - name: Check Darjeeling VM execution
         run: |
-          timeout -s KILL 4 ./qemu-system-riscv32 -M ot-darjeeling,no_epmp_cfg=true -nographic \
-            -object ot-rom_img,id=rom0,file=exit_dj.bin -global ot-ibex_wrapper.lc-ignore=on \
-            -d in_asm,int
+          timeout -s KILL 4 build-clang/qemu-system-riscv32 -M ot-darjeeling,no_epmp_cfg=true -nographic \
+            -object ot-rom_img,id=rom0,file=build-clang/exit_dj.bin -global ot-ibex_wrapper.lc-ignore=on \
+            -readconfig docs/config/opentitan/darjeeling.cfg -d in_asm,int \
+            -trace ot_ibex_wrapper_exit
 
   build-gcc:
     runs-on: ubuntu-24.04

--- a/.gitlab-ci.d/opentitan/ot-smoke.yml
+++ b/.gitlab-ci.d/opentitan/ot-smoke.yml
@@ -8,9 +8,13 @@ smoke-tests-ot:
     - build/qemu-system-riscv32 -M help | grep ot-earlgrey
     - timeout -s KILL 4 build/qemu-system-riscv32 -M ibexdemo -nographic
         -device loader,addr=0x100080,file=build/exit_id.bin -d in_asm,int
-    - timeout -s KILL 4 build/qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -nographic
+    - timeout -s KILL 4 build/qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true
         -object ot-rom_img,id=rom,file=build/exit_eg.bin -d in_asm,int
         -nographic -global ot-ibex_wrapper.lc-ignore=on
+        -readconfig docs/config/opentitan/earlgrey.cfg
+        -trace ot_ibex_wrapper_exit
     - timeout -s KILL 4 build/qemu-system-riscv32 -M ot-darjeeling,no_epmp_cfg=true
         -object ot-rom_img,id=rom0,file=build/exit_dj.bin -d in_asm,int
-         -nographic -global ot-ibex_wrapper.lc-ignore=on
+        -nographic -global ot-ibex_wrapper.lc-ignore=on
+        -readconfig docs/config/opentitan/darjeeling.cfg
+        -trace ot_ibex_wrapper_exit

--- a/docs/config/opentitan/earlgrey.cfg
+++ b/docs/config/opentitan/earlgrey.cfg
@@ -37,8 +37,8 @@
   production = "6d467215dab3f2b54a52e6728678af07"
   raw_unlock_token = "ea2b3f32cbe77554e43c8ea7ebf197c2"
   rma = "18068e344d2eae4d73c8fa54de8aa4a4"
-  socdbg_first = "440af80d"
-  socdbg_last = "6c9ef9cf"
+  soc_dbg_first = "440af80d"
+  soc_dbg_last = "6c9ef9cf"
   test_unlocked = "cfd6a5a5bf3032db51fa1eb92f6ce10e"
 
 [ot_device "ot-keymgr"]
@@ -69,3 +69,4 @@
 
 [ot_device "ot-pwrmgr"]
   clocks = "main,io,usb"
+

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1398,20 +1398,6 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
             OT_DJ_SOC_DEVLINK("clock-src", AST)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("topclocks", "main:16,io:16,aon:1"),
-            IBEX_DEV_STRING_PROP("refclock", "aon"),
-            IBEX_DEV_STRING_PROP("subclocks",
-                "io_div2:io:2,io_div4:io:4,"
-                "aes:main:1,hmac:main:1,kmac:main:1,otbn:main:1"),
-            IBEX_DEV_STRING_PROP("groups",
-                "powerup:aon+io+io_div2+io_div4+main,"
-                "trans:aes+hmac+kmac+otbn,"
-                "infra:aon+io_div4+main,"
-                "secure:io_div4+main,"
-                "peri:aon+io_div2+io_div4,"
-                "timers:aon+io_div4"),
-            IBEX_DEV_STRING_PROP("swcg", "peri"),
-            IBEX_DEV_STRING_PROP("hint", "trans"),
             IBEX_DEV_UINT_PROP("version", OT_CLKMGR_VERSION_DJ)
         ),
     },
@@ -1483,9 +1469,6 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
         .cfg = &ot_dj_soc_ast_configure,
         .memmap = MEMMAPENTRIES(
             { .base = 0x30480000u }
-        ),
-        .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("aonclocks", "aon")
         ),
     },
     [OT_DJ_SOC_DEV_SRAM_CTRL_RET] = {

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -1016,20 +1016,6 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
             OT_EG_SOC_DEVLINK("clock-src", AST)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("topclocks", "main:500,io:480,usb:240,aon:1"),
-            IBEX_DEV_STRING_PROP("refclock", "aon"),
-            IBEX_DEV_STRING_PROP("subclocks",
-                "io_div2:io:2,io_div4:io:4,"
-                "aes:main:1,hmac:main:1,kmac:main:1,otbn:main:1"),
-            IBEX_DEV_STRING_PROP("groups",
-                "powerup:aon+io+io_div2+io_div4+main+usb,"
-                "trans:aes+hmac+kmac+otbn,"
-                "infra:io+io_div2+io_div4+main+usb,"
-                "secure:aon+io_div4+main,"
-                "peri:aon+io+io_div2+io_div4+usb,"
-                "timers:aon+io_div4"),
-            IBEX_DEV_STRING_PROP("swcg", "peri"),
-            IBEX_DEV_STRING_PROP("hint", "trans"),
             IBEX_DEV_UINT_PROP("version", OT_CLKMGR_VERSION_EG_1_0_0)
         ),
     },
@@ -1119,9 +1105,6 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
         .cfg = &ot_eg_soc_ast_configure,
         .memmap = MEMMAPENTRIES(
             { .base = 0x40480000u }
-        ),
-        .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_STRING_PROP("aonclocks", "aon")
         ),
     },
     [OT_EG_SOC_DEV_SENSOR_CTRL] = {


### PR DESCRIPTION
... from clock manager and AST properties.

Clock configuration is always defined in the mandatory machine configuration file. Removing the default values from the machine definition to avoid confusion and data duplication/mismatch.