### PR TITLE
`docs`: Update EG/DJ doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ QEMU is capable of emulating a complete machine in software without any need for
 virtualization support. By using dynamic translation, it achieves very good performance.
 
 This branch contains a fork of QEMU 10.1.0 dedicated to support lowRISC Ibex platforms:
-  * [OpenTitan](https://opentitan.org) [EarlGrey](docs/opentitan/earlgrey.md), based on
+  * [OpenTitan](https://opentitan.org) [EarlGrey](docs/opentitan/ot_earlgrey.md), based on
     [1.0.0](https://github.com/lowRISC/opentitan/tree/earlgrey_1.0.0).
-  * [OpenTitan](https://opentitan.org) [Darjeeling](docs/opentitan/darjeeling.md), based on
+  * [OpenTitan](https://opentitan.org) [Darjeeling](docs/opentitan/ot_darjeeling.md), based on
     [development version](https://github.com/lowRISC/opentitan/tree/master).
-  * [lowRISC](https://github.com/lowRISC/ibex-demo-system) [IbexDemo](ibexdemo.md).
+  * [lowRISC](https://github.com/lowRISC/ibex-demo-system) [IbexDemo](docs/opentitan/ibexdemo.md).
 
 See [installation instructions](docs/opentitan/index.md)
 


### PR DESCRIPTION
When these files were renamed with an `ot_` prefix, the links weren't updated in the main `README.md`.