### PR TITLE
`ot_sram_ctrl`: Connect the lc_ctrl `HW_DEBUG_EN` signal for ifetch / execution enablement

### DIFF
--- a/hw/opentitan/ot_sram_ctrl.c
+++ b/hw/opentitan/ot_sram_ctrl.c
@@ -133,6 +133,7 @@ struct OtSramCtrlState {
     bool initializing; /* CTRL.INIT has been requested */
     bool otp_ifetch; /* whether OTP enable execution from this RAM */
     bool csr_ifetch; /* whether CSR enable execution from this RAM */
+    bool lc_hw_debug_ifetch; /* HW_DEBUG_EN signal from the lc_ctrl */
     char *hexstr;
 
     char *ot_id;
@@ -350,6 +351,17 @@ static void ot_sram_ctrl_start_initialization(OtSramCtrlState *s)
     ot_sram_ctrl_initialize(s, count, false);
 }
 
+static void ot_sram_ctrl_lc_signal(void *opaque, int irq, int level)
+{
+    OtSramCtrlState *s = opaque;
+
+    g_assert(irq == 0);
+
+    trace_ot_sram_ctrl_lc_signal(s->ot_id, level);
+
+    s->lc_hw_debug_ifetch = (bool)level;
+}
+
 static void ot_sram_ctrl_update_exec(OtSramCtrlState *s)
 {
     /*
@@ -363,10 +375,12 @@ static void ot_sram_ctrl_update_exec(OtSramCtrlState *s)
             oc->get_hw_cfg(oi)->en_sram_ifetch_mb8 == OT_MULTIBITBOOL8_TRUE;
     }
 
-    bool ifetch = s->ifetch && s->csr_ifetch && s->otp_ifetch;
+    bool ifetch = s->otp_ifetch ? s->csr_ifetch : s->lc_hw_debug_ifetch;
+    ifetch = ifetch && s->ifetch; /* ifetch config disable */
 
     trace_ot_sram_ctrl_update_exec(s->ot_id, s->ifetch, s->csr_ifetch,
-                                   s->otp_ifetch, ifetch);
+                                   s->otp_ifetch, s->lc_hw_debug_ifetch,
+                                   ifetch);
 
     if (!s->vmapper) {
         if (!ifetch) {
@@ -851,6 +865,9 @@ static void ot_sram_ctrl_init(Object *obj)
     sysbus_init_mmio(SYS_BUS_DEVICE(s), &s->mmio);
 
     ibex_qdev_init_irq(obj, &s->alert, OT_DEVICE_ALERT);
+
+    qdev_init_gpio_in_named(DEVICE(obj), &ot_sram_ctrl_lc_signal,
+                            OT_SRAM_CTRL_HW_DEBUG_EN, 1);
 
     s->mem = g_new0(OtSramCtrlMem, 1u);
     s->init_timer =

--- a/hw/opentitan/trace-events
+++ b/hw/opentitan/trace-events
@@ -618,6 +618,7 @@ ot_sram_ctrl_initialize(const char *id, unsigned start, unsigned end, unsigned c
 ot_sram_ctrl_initialization_complete(const char *id, const char *from) "%s: after %s"
 ot_sram_ctrl_io_read_out(const char *id, uint32_t addr, const char * regname, uint32_t val, uint32_t pc) "%s: addr=0x%02x (%s), val=0x%x, pc=0x%x"
 ot_sram_ctrl_io_write(const char *id, uint32_t addr, const char * regname, uint32_t val, uint32_t pc) "%s: addr=0x%02x (%s), val=0x%x, pc=0x%x"
+ot_sram_ctrl_lc_signal(const char *id, int level) "%s: LC signal level:%d"
 ot_sram_ctrl_mem_io_readi(const char *id, uint32_t addr, unsigned size, uint32_t pc) "%s: addr=0x%06x, size=%u, pc=0x%x"
 ot_sram_ctrl_mem_io_reado(const char *id, uint32_t addr, unsigned size, uint32_t val, uint32_t pc) "%s: addr=0x%06x, size=%u, val=0x%08x, pc=0x%x"
 ot_sram_ctrl_mem_io_write(const char *id, uint32_t addr, unsigned size, uint32_t val, uint32_t pc) "%s: addr=0x%06x, size=%u, val=0x%08x, pc=0x%x"
@@ -628,7 +629,7 @@ ot_sram_ctrl_reseed(const char *id) "%s"
 ot_sram_ctrl_schedule_init(const char *id) "%s"
 ot_sram_ctrl_seed_status(const char *id, bool seed_valid) "%s: seed valid: %u"
 ot_sram_ctrl_switch_mem(const char *id, const char *dest) "%s: to %s"
-ot_sram_ctrl_update_exec(const char *id, bool cifetch, bool rifetch, bool oifetch, bool gifetch) "%s: cfg:%u csr:%u otp:%u res:%u"
+ot_sram_ctrl_update_exec(const char *id, bool cifetch, bool rifetch, bool oifetch, bool lcfetch, bool gifetch) "%s: cfg:%u csr:%u otp:%u lc_hw_debug:%u res:%u"
 
 # ot_timer.c
 

--- a/hw/riscv/ot_darjeeling.c
+++ b/hw/riscv/ot_darjeeling.c
@@ -1500,8 +1500,13 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
     /* IRQ splitters */
     [OT_DJ_SOC_SPLITTER_LC_HW_DEBUG] = {
         .type = TYPE_SPLIT_IRQ,
+        .gpio = IBEXGPIOCONNDEFS(
+            OT_DJ_SOC_S2D(0, SRAM_CTRL_MAIN, OT_SRAM_CTRL_HW_DEBUG_EN, 0),
+            OT_DJ_SOC_S2D(1, SRAM_CTRL_MBOX, OT_SRAM_CTRL_HW_DEBUG_EN, 0),
+            OT_DJ_SOC_S2D(2, SRAM_CTRL_RET, OT_SRAM_CTRL_HW_DEBUG_EN, 0)
+        ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_UINT_PROP("num-lines", 1u) // to be changed
+            IBEX_DEV_UINT_PROP("num-lines", 3u) /* @todo: to be changed */
         )
     },
     [OT_DJ_SOC_SPLITTER_LC_ESCALATE] = {
@@ -1511,7 +1516,7 @@ static const IbexDeviceDef ot_dj_soc_devices[] = {
                                   OT_OTP_LC_ESCALATE_EN)
         ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_UINT_PROP("num-lines", 1u) // to be changed
+            IBEX_DEV_UINT_PROP("num-lines", 1u) /* @todo to be changed */
         )
     }
     /* clang-format on */

--- a/hw/riscv/ot_earlgrey.c
+++ b/hw/riscv/ot_earlgrey.c
@@ -1470,8 +1470,12 @@ static const IbexDeviceDef ot_eg_soc_devices[] = {
     /* IRQ splitters */
     [OT_EG_SOC_SPLITTER_LC_HW_DEBUG] = {
         .type = TYPE_SPLIT_IRQ,
+        .gpio = IBEXGPIOCONNDEFS(
+            OT_EG_SOC_S2D(0, SRAM_MAIN_CTRL, OT_SRAM_CTRL_HW_DEBUG_EN, 0),
+            OT_EG_SOC_S2D(1, SRAM_RET_CTRL, OT_SRAM_CTRL_HW_DEBUG_EN, 0)
+        ),
         .prop = IBEXDEVICEPROPDEFS(
-            IBEX_DEV_UINT_PROP("num-lines", 1u) /* @todo to be changed */
+            IBEX_DEV_UINT_PROP("num-lines", 2u) /* @todo to be changed */
         )
     },
     [OT_EG_SOC_SPLITTER_LC_ESCALATE] = {

--- a/include/hw/opentitan/ot_sram_ctrl.h
+++ b/include/hw/opentitan/ot_sram_ctrl.h
@@ -33,4 +33,7 @@
 #define TYPE_OT_SRAM_CTRL "ot-sram_ctrl"
 OBJECT_DECLARE_TYPE(OtSramCtrlState, OtSramCtrlClass, OT_SRAM_CTRL)
 
+/* Input HW_DEBUG_EN signal for SRAM ifetch (from lifecycle controller) */
+#define OT_SRAM_CTRL_HW_DEBUG_EN TYPE_OT_SRAM_CTRL "-hw_debug_en"
+
 #endif /* HW_OPENTITAN_OT_SRAM_CTRL */


### PR DESCRIPTION
The current SRAM controller ifetch / execution enablement logic only considers that the configured `ifetch` enable property should be true, in addition to the OTP `HW_CFG1.EN_SRAM_IFETCH` field and the sram_ctrl CSR `EXEC.EN` field. This is likely based on the [`EXEC.EN` documentation](https://opentitan.org/book/hw/ip/sram_ctrl/doc/registers.html#exec--en) which states that:

> Note that this register only takes effect if the EN_SRAM_IFETCH switch in the OTP HW_CFG1 partition is set to kMultiBitBool8True. Otherwise execution from SRAM cannot be enabled via this register.

While this isn't incorrect, it doesn't paint the full picture. From the [RTL](https://github.com/lowRISC/opentitan/blob/5da2042067deaface38c8b8b102c007032d121ed/hw/ip/sram_ctrl/rtl/sram_ctrl.sv#L434-L442):

```sv
    assign en_ifetch = (mubi8_test_true_strict(otp_en_sram_ifetch)) ? reg_ifetch_en :
                                                                      lc_ifetch_en;
```
In the case that the OTP iftech is disabled, the CSR value is entirely ignored and instead the value of the pervasive lifecycle controller `hw_debug_en` broadcast signal is used to determine SRAM ifetch enablement. This PR implements this functionality, retaining the behaviour that the `ifetch` config property acts a disable regardless of the `HW_DEBUG_EN` value.