### PR TITLE
[ot] util: fifo8: remove `fifo8_consume_all` API

### DIFF
--- a/hw/ibexdemo/ibexdemo_uart.c
+++ b/hw/ibexdemo/ibexdemo_uart.c
@@ -108,7 +108,7 @@ static void ibexdemo_uart_xmit(IbexDemoUARTState *s)
     ret = qemu_chr_fe_write(&s->chr, buf, size);
 
     if (ret > 0) {
-        fifo8_consume_all(&s->tx_fifo, ret);
+        fifo8_drop(&s->tx_fifo, ret);
     }
 }
 

--- a/hw/opentitan/ot_uart.c
+++ b/hw/opentitan/ot_uart.c
@@ -369,7 +369,7 @@ static void ot_uart_xmit(OtUARTState *s)
         ret = qemu_chr_fe_write(&s->chr, buf, (int)size);
         /* if some characters where sent, remove them from the FIFO */
         if (ret >= 0) {
-            fifo8_consume_all(&s->tx_fifo, ret);
+            fifo8_drop(&s->tx_fifo, ret);
         }
     }
 

--- a/include/hw/opentitan/ot_fifo32.h
+++ b/include/hw/opentitan/ot_fifo32.h
@@ -96,14 +96,6 @@ ot_fifo32_peek_buf(const OtFifo32 *fifo, uint32_t max, uint32_t *num)
     return ret;
 }
 
-static inline void ot_fifo32_consume_all(OtFifo32 *fifo, uint32_t num)
-{
-    num = MIN(fifo->capacity - fifo->head, num);
-    fifo->head += num;
-    fifo->head %= fifo->capacity;
-    fifo->num -= num;
-}
-
 static inline void ot_fifo32_reset(OtFifo32 *fifo)
 {
     fifo->num = 0u;

--- a/include/qemu/fifo8.h
+++ b/include/qemu/fifo8.h
@@ -166,18 +166,6 @@ const uint8_t *fifo8_peek_bufptr(Fifo8 *fifo, uint32_t max, uint32_t *numptr);
 void fifo8_drop(Fifo8 *fifo, uint32_t len);
 
 /**
- * fifo8_consume_all:
- * @fifo: fifo to consume from
- * @num: number of bytes to consume
- *
- * Remove data bytes from the FIFO. Behaviour is undefined if the FIFO is empty.
- * Clients are responsible for checking for emptyness using fifo8_is_empty().
- *
- */
-
-void fifo8_consume_all(Fifo8 *fifo, uint32_t num);
-
-/**
  * fifo8_reset:
  * @fifo: FIFO to reset
  *

--- a/util/fifo8.c
+++ b/util/fifo8.c
@@ -101,14 +101,6 @@ static const uint8_t *fifo8_peekpop_bufptr(Fifo8 *fifo, uint32_t max,
     return ret;
 }
 
-void fifo8_consume_all(Fifo8 *fifo, uint32_t num)
-{
-    num = MIN(fifo->capacity - fifo->head, num);
-    fifo->head += num;
-    fifo->head %= fifo->capacity;
-    fifo->num -= num;
-}
-
 const uint8_t *fifo8_peek_bufptr(Fifo8 *fifo, uint32_t max, uint32_t *numptr)
 {
     return fifo8_peekpop_bufptr(fifo, max, 0, numptr, false);


### PR DESCRIPTION
Upstream QEMU has added an equivalent `fifo8_drop` function in the time since this was introduced.