### PR TITLE
[ot] system: memory: remove unused `mtree_print_as_{flatview,simple}` APIs

### DIFF
--- a/include/system/memory.h
+++ b/include/system/memory.h
@@ -2678,9 +2678,6 @@ bool memory_global_dirty_log_start(unsigned int flags, Error **errp);
 void memory_global_dirty_log_stop(unsigned int flags);
 
 void mtree_info(bool flatview, bool dispatch_tree, bool owner, bool disabled);
-void mtree_print_as_flatview(AddressSpace *as, bool dispatch_tree, bool owner);
-void mtree_print_as_simple(AddressSpace *as, bool dispatch_tree, bool owner,
-                           bool disabled);
 
 bool memory_region_access_valid(MemoryRegion *mr, hwaddr addr,
                                 unsigned size, bool is_write,

--- a/system/memory.c
+++ b/system/memory.c
@@ -3581,38 +3581,6 @@ static void mtree_print_flatview(gpointer key, gpointer value,
     qemu_printf("\n");
 }
 
-void mtree_print_as_flatview(AddressSpace *as, bool dispatch_tree, bool owner)
-{
-    struct FlatViewInfo fvi = {
-        .counter = 0,
-        .dispatch_tree = dispatch_tree,
-        .owner = owner,
-    };
-
-    FlatView *view = address_space_get_flatview(as);
-    AccelClass *ac = ACCEL_GET_CLASS(current_accel());
-    if (ac->has_memory) {
-        fvi.ac = ac;
-    }
-
-    GArray *ases = g_array_new(false, false, sizeof(as));
-    g_array_append_val(ases, as);
-
-    mtree_print_flatview(view, ases, &fvi);
-
-    g_array_free(ases, false);
-}
-
-static void mtree_info_as(bool dispatch_tree, bool owner, bool disabled,
-                          AddressSpace *sas);
-
-void mtree_print_as_simple(AddressSpace *as, bool dispatch_tree, bool owner,
-                           bool disabled)
-{
-    mtree_info_as(dispatch_tree, owner, disabled, as);
-}
-
-
 static gboolean mtree_info_flatview_free(gpointer key, gpointer value,
                                       gpointer user_data)
 {
@@ -3706,8 +3674,7 @@ static gboolean mtree_info_as_free(gpointer key, gpointer value,
     return true;
 }
 
-static void mtree_info_as(bool dispatch_tree, bool owner, bool disabled,
-                          AddressSpace *sas)
+static void mtree_info_as(bool dispatch_tree, bool owner, bool disabled)
 {
     MemoryRegionListHead ml_head;
     MemoryRegionList *ml, *ml2;
@@ -3723,9 +3690,6 @@ static void mtree_info_as(bool dispatch_tree, bool owner, bool disabled,
     QTAILQ_INIT(&ml_head);
 
     QTAILQ_FOREACH(as, &address_spaces, address_spaces_link) {
-        if (sas && as != sas) {
-            continue;
-        }
         /* Create hashtable, key=AS root MR, value = list of AS */
         as_same_root_mr_list = g_hash_table_lookup(views, as->root);
         as_same_root_mr_list = g_slist_insert_sorted(as_same_root_mr_list, as,
@@ -3755,7 +3719,7 @@ void mtree_info(bool flatview, bool dispatch_tree, bool owner, bool disabled)
     if (flatview) {
         mtree_info_flatview(dispatch_tree, owner);
     } else {
-        mtree_info_as(dispatch_tree, owner, disabled, NULL);
+        mtree_info_as(dispatch_tree, owner, disabled);
     }
 }
 


### PR DESCRIPTION
I think these must have been used for debugging. We can keep them if necessary but during a rebase I wasn't sure where to put them.