### PR TITLE
[ot] target/riscv: csr: remove duplicate predicate check

### DIFF
--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -5630,11 +5630,6 @@ static inline RISCVException riscv_csrrw_check(CPURISCVState *env,
         return RISCV_EXCP_ILLEGAL_INST;
     }
 
-    /* ensure CSR is implemented by checking predicate */
-    if (!csr_ops[csrno].predicate) {
-        return RISCV_EXCP_ILLEGAL_INST;
-    }
-
     /* privileged spec version check */
     if (env->priv_ver < csr_min_priv) {
         return RISCV_EXCP_ILLEGAL_INST;


### PR DESCRIPTION
This is duplicated below. It must have been copied in a merge conflict or similar.