### PR TITLE
[ot] meson.build: options: re-enable `-lundef`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,6 @@
 project('qemu', ['c', 'rust'], meson_version: '>=1.5.0',
         default_options: ['warning_level=1', 'c_std=gnu11', 'cpp_std=gnu++11', 'b_colorout=auto',
-                          'b_staticpic=false', 'stdsplit=false', 'optimization=2', 'b_pie=true',
-                          'b_lundef=false'],
+                          'b_staticpic=false', 'stdsplit=false', 'optimization=2', 'b_pie=true'],
         version: files('VERSION'))
 
 meson.add_devenv({ 'MESON_BUILD_ROOT' : meson.project_build_root() })
@@ -3597,7 +3596,7 @@ trace_events_subdirs = [
   'qom',
   'monitor',
   'util',
-  'gdbstub'
+  'gdbstub',
 ]
 if have_linux_user
   trace_events_subdirs += [ 'linux-user' ]


### PR DESCRIPTION
Our project does satisfy `-lundef` ("Don't allow undefined symbols when linking") so I would prefer not to deviate from upstream QEMU.

Re-added a dropped trailing comma while I'm here.