### PR TITLE
[ot] tests/opentitan: earlgrey-tests: Add SPI Host smoke and flash tests

### DIFF
--- a/tests/opentitan/data/earlgrey-tests.txt
+++ b/tests/opentitan/data/earlgrey-tests.txt
@@ -534,6 +534,10 @@ pass: //sw/device/tests:spi_device_tpm_tx_rx_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:spi_device_tpm_tx_rx_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:spi_host_irq_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:spi_host_irq_test_sim_qemu_sival_rom_ext
+pass: //sw/device/tests:spi_host_smoketest_sim_qemu_rom_with_fake_keys
+pass: //sw/device/tests:spi_host_smoketest_sim_qemu_sival_rom_ext
+pass: //sw/device/tests:spi_host_winbond_flash_test_sim_qemu_rom_with_fake_keys
+pass: //sw/device/tests:spi_host_winbond_flash_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:spi_passthru_test_sim_qemu_rom_with_fake_keys
 pass: //sw/device/tests:spi_passthru_test_sim_qemu_sival_rom_ext
 pass: //sw/device/tests:sram_ctrl_execution_test_sim_qemu_rom_with_fake_keys


### PR DESCRIPTION
Depends on https://github.com/lowRISC/opentitan/pull/30286 (and cherry-pick to 1.0.0).