### PR TITLE
Bump `ethnum-rs` and `dtc` dependencies

### DIFF
--- a/subprojects/dtc.wrap
+++ b/subprojects/dtc.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://gitlab.com/qemu-project/dtc.git
-revision = b6910bec11614980a21e46fbccc35934b671bd81
+revision = 66e1201c3775716607c28afd2bbb2b3afb08b695
 depth = 1

--- a/subprojects/ethnum-rs.wrap
+++ b/subprojects/ethnum-rs.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = ethnum-rs-1.3.0
-source_url = https://github.com/nlordell/ethnum-rs/archive/refs/tags/v1.3.0.tar.gz
-source_filename = ethnum-rs-1.3.0.tar.gz
-source_hash = 65d2f954d998565cfdd5ac107862e13c9ac2ed62cc68c454c5690c0982b9e02a
+directory = ethnum-rs-1.5.3
+source_url = https://github.com/nlordell/ethnum-rs/archive/refs/tags/v1.5.3.tar.gz
+source_filename = ethnum-rs-1.5.3.tar.gz
+source_hash = 7d2786be23a7b34b0bc873c9306da4ecf8123c436b0ec83dfe6d6892a986a7f2
 
 diff_files = ethnum-rs/0001.patch

--- a/subprojects/packagefiles/ethnum-rs/0001.patch
+++ b/subprojects/packagefiles/ethnum-rs/0001.patch
@@ -4,7 +4,7 @@ index 0000000000..1f7c0456e8
 --- /dev/null
 +++ b/meson.build
 @@ -0,0 +1,8 @@
-+project('ethnum', 'rust', version: '1.3.2')
++project('ethnum', 'rust', version: '1.5.3')
 +
 +ethnum_lib = static_library('ethnum',
 +                            'src/lib.rs',


### PR DESCRIPTION
Both dependencies have errors which fail to compile using recent compilers. We build QEMU with host tools in OpenTitan (due to how `rules_foreign_cc` works) and the build recently started failing due to the `ethnum-rs` Rust error.

When I fixed the Rust error locally, my C host compiler rejected `libdtc` due to another problem (Ubuntu 26.04). See the commit messages for details.